### PR TITLE
Add loading placeholder with fade-out to blog page

### DIFF
--- a/pages/Blog/Blog.html
+++ b/pages/Blog/Blog.html
@@ -32,7 +32,9 @@
   <section data-section="blog">
     <div id="blog-container" class="page-container">
       <div id="blog-list">
-        <!-- Post cards injected by JS -->
+        <div class="loading-placeholder" id="blog-loading">
+          Loading posts<span class="dot dot1">.</span><span class="dot dot2">.</span><span class="dot dot3">.</span>
+        </div>
       </div>
 
       <div id="post-view" style="display: none;">

--- a/scripts/blog.js
+++ b/scripts/blog.js
@@ -56,6 +56,11 @@ function parsePostBody(text) {
 function renderBlogList() {
   const container = document.getElementById('blog-list');
   container.innerHTML = '';
+  const loading = document.getElementById('blog-loading');
+  if (loading) {
+    loading.classList.add('fade-out');
+    loading.addEventListener('animationend', () => loading.remove(), { once: true });
+  }
   let sectionIndex = 0;
   let delayIndex = 0;
   categories.forEach(category => {

--- a/styles/Blog.css
+++ b/styles/Blog.css
@@ -4,6 +4,37 @@
   gap: 1.5rem;
 }
 
+.loading-placeholder {
+  text-align: center;
+  padding: 2rem;
+  font-size: 1rem;
+  color: var(--shadowColor);
+  opacity: 0.7;
+}
+
+.dot {
+  opacity: 0;
+  animation: dotPulse 1.4s infinite;
+}
+
+.dot1 { animation-delay: 0s; }
+.dot2 { animation-delay: 0.2s; }
+.dot3 { animation-delay: 0.4s; }
+
+@keyframes dotPulse {
+  0%, 20% { opacity: 0; }
+  50% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.fade-out {
+  animation: fadeOut 0.4s ease forwards;
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; }
+}
+
 .blog-section {
   min-width: 0;
 }


### PR DESCRIPTION
Closes #13

## What

Add an animated loading placeholder to the blog page that displays while blog posts are being rendered from static files.

## Why

Users previously saw a blank area while the blog was loading posts, providing no visual feedback. The loading placeholder improves perceived performance and keeps users engaged during the brief delay of parsing and rendering static post files.

## Changes

- **`pages/Blog/Blog.html`** — Added a loading placeholder element with animated dots
- **`scripts/blog.js`** — Fade-out and remove the loading placeholder once blog posts are rendered
- **`styles/Blog.css`** — Styles for the loading state with dot-pulse animation and fade-out transition

## How it works

1. A "Loading posts..." placeholder with three pulsing dots is shown by default in the blog container
2. When `renderBlogList()` starts, it finds the loading element and adds a `fade-out` class
3. The fade-out animation runs for 0.4 seconds with eased timing
4. On `animationend`, the loading element is removed from the DOM
5. Blog post cards are rendered immediately after fade-out begins

## To verify

1. Navigate to `/pages/Blog/Blog.html`
2. Observe the "Loading posts..." text with pulsing dots appear on page load
3. Watch the placeholder fade out smoothly as blog posts appear
