### PR TITLE
Add LeetCode activity/submissions card and GitHub issues to Projects page

### DIFF
--- a/styles/Projects.css
+++ b/styles/Projects.css
@@ -233,6 +233,11 @@
   margin-top: 1.5rem;
 }
 
+#lc-submissions-card:hover {
+  transform: none;
+  box-shadow: 0.3rem 0.3rem var(--shadowColor);
+}
+
 .lc-activity {
   position: relative;
   min-height: 6rem;


### PR DESCRIPTION
Closes #24

## What

Removing the hover animation on Leetcode Submission Card

## Why

There is a tooltip in the graph, the hover animation is visually unnecessary and distracts from the overlay tooltip for a split second

## Changes

- **`styles/Projects.css`**: Add `lc-submissions-card:hover` overriding the `.card:hover` styles in `common.styles`

## How it works

The `Project.css` styles override the card styles in `common.css`

## To verify

1. Open `pages/Projects/Projects.html` in a browser — the "Leetcode Progress" section has the "Recent Submissions & Activities" card
2. Hover over it to see the card does not have animation
3. Hover the bar chart and see the overlay tooltip pops up for individual graphs 
