### PR TITLE
Rename Projects page to MySpace

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -95,7 +95,7 @@ jobs:
             }
 
             function getLeetcodeApi() {
-              var projectsPath = 'pages/Projects/Projects.html';
+              var projectsPath = 'pages/MySpace/MySpace.html';
               if (!fs.existsSync(projectsPath)) return null;
               var content = fs.readFileSync(projectsPath, 'utf8');
               var match = content.match(/https:\/\/leetcode-stats\.tashif\.codes\/[\w]+/);
@@ -103,7 +103,7 @@ jobs:
             }
 
             function getGitHubUser() {
-              var projectsPath = 'pages/Projects/Projects.html';
+              var projectsPath = 'pages/MySpace/MySpace.html';
               if (!fs.existsSync(projectsPath)) return null;
               var content = fs.readFileSync(projectsPath, 'utf8');
               var match = content.match(/api\.github\.com\/users\/[\w-]+/);
@@ -118,7 +118,7 @@ jobs:
             }
 
             function detectNoticeRoutes() {
-              var files = ['index.html', 'pages/Resume/Resume.html', 'pages/Blog/Blog.html', 'pages/Projects/Projects.html'];
+              var files = ['index.html', 'pages/Resume/Resume.html', 'pages/Blog/Blog.html', 'pages/MySpace/MySpace.html'];
               var routes = [];
               for (var fi = 0; fi < files.length; fi++) {
                 var file = files[fi];
@@ -185,7 +185,7 @@ jobs:
                 details.push('Recent activity / commit via GitHub API (`fetchRecentActivity()`)');
               }
               if (scripts.indexOf('shared.js') !== -1) {
-                details.push('`shared.js` (`notice()`, dropdown + footer `menuIcon` toggle via `initMenuToggle()`)');
+                details.push('`shared.js` (footer `menuIcon` toggle via `initMenuToggle()`)');
               }
 
               return { styles: styles, scripts: scripts, details: details };
@@ -268,7 +268,7 @@ jobs:
             lines.push('- **Shared header/footer**: The `<header>` (brand + nav dropdown) and footer social-SVG block are **duplicated verbatim across pages** \u2014 any nav or footer change must be applied to every page. `.active` class marks the current page\'s nav link. Sub-pages use `<body class="sub-page">`; `index.html` does not.');
             var sharedCssLabel = sharedStyles.length ? sharedStyles.map(function(s) { return '`' + s + '`'; }).join(', ') : 'none';
             var sharedJsLabel = sharedScripts.length ? sharedScripts.map(function(s) { return '`' + s + '`'; }).join(', ') : 'none';
-            lines.push('- **Shared JS/CSS**: Files loaded by every page: CSS ' + sharedCssLabel + '; JS ' + sharedJsLabel + '. `scripts/shared.js` provides `notice()`, nav-dropdown logic, and the footer `menuIcon` toggle (`initMenuToggle()`); `styles/style.css` holds the custom-property theme. Page-specific logic lives in `scripts/{home,blog,projects,resume}.js` and page CSS in `styles/{Blog,Projects,Resume}.css`. Load order: `style.css` (\+ `common.css` on sub-pages) first, then page CSS, then `shared.js` before the page script. Put cross-page JS in `shared.js`, cross-page CSS in `common.css`.');
+            lines.push('- **Shared JS/CSS**: Files loaded by every page: CSS ' + sharedCssLabel + '; JS ' + sharedJsLabel + '. `scripts/shared.js` provides the footer `menuIcon` toggle (`initMenuToggle()`); `styles/style.css` holds the custom-property theme. Page-specific logic lives in `scripts/{home,blog,myspace,resume}.js` and page CSS in `styles/{Blog,MySpace,Resume}.css`. Load order: `style.css` (\+ `common.css` on sub-pages) first, then page CSS, then `shared.js` before the page script. Put cross-page JS in `shared.js`, cross-page CSS in `common.css`.');
             lines.push('- **Theming**: All colors and fonts come from CSS custom properties in `:root` of `style.css` (`--borderColor`, `--backgroundColor`, `--shadowColor`, `--contentColor`, `--headings`, `--poppins`, etc.). Never hardcode colors \u2014 use the variables. Fonts are imported at the top of `style.css`.');
             lines.push('- **Layout**: `index.html` is a full-height grid hero; sub-pages use `body.sub-page` and scroll normally (they do **not** use `overflow:hidden`). Sections are often collapsible (`toggleSection()` / `toggleBlogSection()` with +/- icons). Uses `720px` breakpoint for responsive work.');
             lines.push('- **Visual language**: Beige background, black borders, offset solid box-shadows (`--shadowColor`), rounded corners. Reuse existing patterns (`.card`, `.skill-item`, `.stat-card` styling) rather than inventing new ones.');

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": {
+      "*": "allow",
+      "README.md": "deny",
+      "**/README.md": "deny"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Making my own dynamic blogging website!
 ├── pages/
 │   ├── Blog/
 │   │   └── Blog.html
-│   ├── Projects/
-│   │   └── Projects.html
+│   ├── MySpace/
+│   │   └── MySpace.html
 │   └── Resume/
 │       └── Resume.html
 ├── scripts/
 │   ├── blog.js
 │   ├── home.js
-│   ├── projects.js
+│   ├── myspace.js
 │   ├── resume.js
 │   └── shared.js
 ├── src/
@@ -67,7 +67,7 @@ Making my own dynamic blogging website!
 ├── styles/
 │   ├── Blog.css
 │   ├── Home.css
-│   ├── Projects.css
+│   ├── MySpace.css
 │   ├── Resume.css
 │   └── styles.css
 ├── .gitignore
@@ -80,18 +80,18 @@ Making my own dynamic blogging website!
 |---|---|---|---|
 | `index.html` | `Home.css` | `shared.js`, `home.js` | Time-based greeting into `#salutation`; `shared.js` (`notice()`, dropdown + footer `menuIcon` toggle via `initMenuToggle()`) |
 | `pages/Blog/Blog.html` | `Home.css` + `styles.css` + `Blog.css` | `shared.js`, `blog.js` | Renders posts from `posts.json` manifest; `renderBlogList()` grouped by category; `showPost()`/`showBlogList()` view-swap; `toggleBlogSection()` collapsible categories; `shared.js` (`notice()`, dropdown + footer `menuIcon` toggle via `initMenuToggle()`) |
-| `pages/Projects/Projects.html` | `Home.css` + `styles.css` + `Projects.css` | `shared.js`, `projects.js` | `toggleSection()` collapsible sections (+/- icons); LeetCode stats via third-party API (`fetchLeetCodeStats()`); GitHub repos/stats via GitHub API (`fetchGitHubStats()`); Recent activity / commit via GitHub API (`fetchRecentActivity()`); `shared.js` (`notice()`, dropdown + footer `menuIcon` toggle via `initMenuToggle()`) |
+| `pages/MySpace/MySpace.html` | `Home.css` + `styles.css` + `MySpace.css` | `shared.js`, `myspace.js` | `toggleSection()` collapsible sections (+/- icons); LeetCode stats via third-party API (`fetchLeetCodeStats()`); GitHub repos/stats via GitHub API (`fetchGitHubStats()`); Recent activity / commit via GitHub API (`fetchRecentActivity()`); `shared.js` (`notice()`, dropdown + footer `menuIcon` toggle via `initMenuToggle()`) |
 | `pages/Resume/Resume.html` | `Home.css` + `styles.css` + `Resume.css` | `shared.js`, `resume.js` | `toggleSection()` collapsible sections (+/- icons); `shared.js` (`notice()`, dropdown + footer `menuIcon` toggle via `initMenuToggle()`) |
 
 ## Key details / conventions
 
 - **Shared header/footer**: The `<header>` (brand + nav dropdown) and footer social-SVG block are **duplicated verbatim across pages** — any nav or footer change must be applied to every page. `.active` class marks the current page's nav link. Sub-pages use `<body class="sub-page">`; `index.html` does not.
-- **Shared JS/CSS**: Files loaded by every page: CSS `Home.css`; JS `shared.js`. `scripts/shared.js` provides `notice()`, nav-dropdown logic, and the footer `menuIcon` toggle (`initMenuToggle()`); `styles/style.css` holds the custom-property theme. Page-specific logic lives in `scripts/{home,blog,projects,resume}.js` and page CSS in `styles/{Blog,Projects,Resume}.css`. Load order: `style.css` (+ `common.css` on sub-pages) first, then page CSS, then `shared.js` before the page script. Put cross-page JS in `shared.js`, cross-page CSS in `common.css`.
+- **Shared JS/CSS**: Files loaded by every page: CSS `Home.css`; JS `shared.js`. `scripts/shared.js` provides `notice()`, nav-dropdown logic, and the footer `menuIcon` toggle (`initMenuToggle()`); `styles/style.css` holds the custom-property theme. Page-specific logic lives in `scripts/{home,blog,myspace,resume}.js` and page CSS in `styles/{Blog,MySpace,Resume}.css`. Load order: `style.css` (+ `common.css` on sub-pages) first, then page CSS, then `shared.js` before the page script. Put cross-page JS in `shared.js`, cross-page CSS in `common.css`.
 - **Theming**: All colors and fonts come from CSS custom properties in `:root` of `style.css` (`--borderColor`, `--backgroundColor`, `--shadowColor`, `--contentColor`, `--headings`, `--poppins`, etc.). Never hardcode colors — use the variables. Fonts are imported at the top of `style.css`.
 - **Layout**: `index.html` is a full-height grid hero; sub-pages use `body.sub-page` and scroll normally (they do **not** use `overflow:hidden`). Sections are often collapsible (`toggleSection()` / `toggleBlogSection()` with +/- icons). Uses `720px` breakpoint for responsive work.
 - **Visual language**: Beige background, black borders, offset solid box-shadows (`--shadowColor`), rounded corners. Reuse existing patterns (`.card`, `.skill-item`, `.stat-card` styling) rather than inventing new ones.
 - **Assets**: `Images/` holds shared assets: `MyImage.jpg` (hero photo) plus social/menu/signature SVGs plus `Images/Graphics/` (blog/project banner art). Footer social icons are inline SVGs in the HTML, not `<img>` tags.
-- **Unbuilt routes**: `mySpace` currently call `notice()` ("Under Development!")
+- **Unbuilt routes**: All nav routes are built
 - **Content source**: `src/cv.md` is the canonical CV text; `Resume.html` renders it via `scripts/resume.js`. `src/Blogs/posts.json` is the blog manifest (ordered list of `src/Blogs/*.md`); `Blog.html` renders via `scripts/blog.js`. Update the relevant source when content changes.
 - **Git**: Default branch is `main`; deploys straight from repo root to GitHub Pages. Keep everything relative-pathed (`./style.css`, `../../styles/common.css`), never absolute paths.
 

--- a/index.html
+++ b/index.html
@@ -22,12 +22,8 @@
         <li>
           <a href="pages/Blog/Blog.html" target="_self">Blog</a>
         </li>
-        <li class="nav-dropdown">
-          <a href="#">Projects</a>
-          <ul class="dropdown">
-            <li><a href="pages/Projects/Projects.html" target="_self">Professional</a></li>
-            <li><a onclick="notice()" href="#">mySpace</a></li>
-          </ul>
+        <li>
+          <a href="pages/MySpace/MySpace.html" target="_self">MySpace</a>
         </li>
       </ul>
     </nav>

--- a/pages/Blog/Blog.html
+++ b/pages/Blog/Blog.html
@@ -18,13 +18,7 @@
         <li><a href="../../index.html" target="_self">Home</a></li>
         <li><a href="../Resume/Resume.html" target="_self">Resume</a></li>
         <li><a class="active" href="./Blog.html" target="_self">Blog</a></li>
-        <li class="nav-dropdown">
-          <a href="#">Projects</a>
-          <ul class="dropdown">
-            <li><a href="../Projects/Projects.html" target="_self">Professional</a></li>
-            <li><a onclick="notice()" href="#">mySpace</a></li>
-          </ul>
-        </li>
+        <li><a href="../MySpace/MySpace.html" target="_self">MySpace</a></li>
       </ul>
     </nav>
   </header>

--- a/pages/MySpace/MySpace.html
+++ b/pages/MySpace/MySpace.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/styles.css"/>
-  <link rel="stylesheet" href="../../styles/Projects.css"/>
-  <title>Projects - Ujjwal Verma</title>
+  <link rel="stylesheet" href="../../styles/MySpace.css"/>
+  <title>MySpace - Ujjwal Verma</title>
 </head>
 <body class="sub-page">
   <span id="menuIcon">&lt;</span>
@@ -18,21 +18,15 @@
         <li><a href="../../index.html" target="_self">Home</a></li>
         <li><a href="../Resume/Resume.html" target="_self">Resume</a></li>
         <li><a href="../Blog/Blog.html" target="_self">Blog</a></li>
-        <li class="nav-dropdown">
-          <a href="#">Projects</a>
-          <ul class="dropdown">
-            <li><a href="./Projects.html" target="_self" class="active">Professional</a></li>
-            <li><a onclick="notice()" href="#">mySpace</a></li>
-          </ul>
-        </li>
+        <li><a href="./MySpace.html" target="_self" class="active">MySpace</a></li>
       </ul>
     </nav>
   </header>
 
-  <section data-section="projects">
-    <div id="projects-container" class="page-container">
+  <section data-section="myspace">
+    <div id="myspace-container" class="page-container">
 
-      <div class="projects-section">
+      <div class="myspace-section">
         <h2 class="section-heading active" onclick="toggleSection(this)">
           <span class="title-text">Currently Working On</span>
           <span class="toggle-icon">-</span>
@@ -41,7 +35,7 @@
           <div id="activity-card" class="card">
             <h3 class="card-title">
               <span id="repo-name"></span>
-              <span class="project-tag">Commit</span>
+              <span class="myspace-tag">Commit</span>
             </h3>
             <p id="commit-message" class="card-excerpt"></p>
             <a id="commit-link" class="card-link" href="#" target="_blank">View on GitHub →</a>
@@ -56,7 +50,7 @@
         </div>
       </div>
 
-      <div class="projects-section">
+      <div class="myspace-section">
         <h2 class="section-heading" onclick="toggleSection(this)">
           <span class="title-text">GitHub Repositories</span>
           <span class="toggle-icon">+</span>
@@ -73,7 +67,7 @@
         </div>
       </div>
 
-      <div class="projects-section">
+      <div class="myspace-section">
         <h2 class="section-heading" onclick="toggleSection(this)">
           <span class="title-text">Latest from the Blog</span>
           <span class="toggle-icon">+</span>
@@ -89,7 +83,7 @@
         </div>
       </div>
 
-      <div class="projects-section">
+      <div class="myspace-section">
         <h2 class="section-heading" onclick="toggleSection(this)">
           <span class="title-text">LeetCode Progress</span>
           <span class="toggle-icon">+</span>
@@ -178,6 +172,6 @@
 
 
   <script src="../../scripts/shared.js"></script>
-  <script src="../../scripts/projects.js"></script>
+  <script src="../../scripts/myspace.js"></script>
 </body>
 </html>

--- a/pages/Resume/Resume.html
+++ b/pages/Resume/Resume.html
@@ -24,12 +24,8 @@
         <li>
           <a href="../Blog/Blog.html" target="_self">Blog</a>
         </li>
-        <li class="nav-dropdown">
-          <a href="#">Projects</a>
-          <ul class="dropdown">
-            <li><a href="../Projects/Projects.html" target="_self">Professional</a></li>
-            <li><a onclick="notice()" href="#">mySpace</a></li>
-          </ul>
+        <li>
+          <a href="../MySpace/MySpace.html" target="_self">MySpace</a>
         </li>
       </ul>
     </nav>

--- a/plan/plan_rename_projects_to_myspace.md
+++ b/plan/plan_rename_projects_to_myspace.md
@@ -1,0 +1,66 @@
+# Rename "Projects" → "MySpace" (MySpace page stack only)
+
+Rename the `pages/Projects/Projects.html` section to `MySpace` — directory, files, UI (nav + title), and code (IDs/classes/JS/CSS). The unrelated "Projects" CV section (`resume.js`/`Resume.css`) and the blog "Personal Projects" category are **out of scope** and left untouched.
+
+## Files to rename
+- `pages/Projects/` directory → `pages/MySpace/`
+- `pages/Projects/Projects.html` → `pages/MySpace/MySpace.html`
+- `scripts/projects.js` → `scripts/myspace.js`
+- `styles/Projects.css` → `styles/MySpace.css`
+
+## 1. `pages/MySpace/MySpace.html`
+- CSS link `../../styles/Projects.css` → `../../styles/MySpace.css`
+- `<title>Projects - Ujjwal Verma</title>` → `<title>MySpace - Ujjwal Verma</title>`
+- **Nav**: replace the dropdown
+  ```html
+  <li class="nav-dropdown">
+    <a href="#">Projects</a>
+    <ul class="dropdown">
+      <li><a href="./Projects.html" target="_self" class="active">Professional</a></li>
+      <li><a onclick="notice()" href="#">mySpace</a></li>
+    </ul>
+  </li>
+  ```
+  with a single direct link (this page):
+  ```html
+  <li><a href="./MySpace.html" target="_self" class="active">MySpace</a></li>
+  ```
+  (dropdown + `mySpace` notice item removed; `.active` moves to the single link)
+- `data-section="projects"` → `data-section="myspace"`
+- `id="projects-container"` → `id="myspace-container"`
+- `class="projects-section"` (×4) → `class="myspace-section"`
+- `class="project-tag"` (line 44, activity card) → `class="myspace-tag"`
+- Script `../../scripts/projects.js` → `../../scripts/myspace.js`
+
+## 2. `scripts/myspace.js` (renamed from `scripts/projects.js`)
+- `tagSpan.className = 'project-tag'` → `'myspace-tag'`
+- `initMenuToggle('#projects-container')` → `initMenuToggle('#myspace-container')`
+
+## 3. `styles/MySpace.css` (renamed from `styles/Projects.css`)
+- Change the `.project-tag` selector (line 82) → `.myspace-tag`
+
+## 4. Nav in the other 3 HTML pages (index.html, Blog.html, Resume.html)
+Each currently has the dropdown `Projects ▸ [Professional][mySpace]`. Replace with a single direct link (no `.active` — that belongs to the current page):
+- `index.html`: `<li><a href="pages/MySpace/MySpace.html" target="_self">MySpace</a></li>`
+- `pages/Blog/Blog.html` and `pages/Resume/Resume.html`:
+  `<li><a href="../MySpace/MySpace.html" target="_self">MySpace</a></li>`
+
+## 5. `.github/workflows/update-readme.yml`
+- Lines 98 & 106 (`getLeetcodeApi` / `getGitHubUser`): `pages/Projects/Projects.html` → `pages/MySpace/MySpace.html`
+- Line 121 (`detectNoticeRoutes` file list): same rename
+- Line 271 (Shared JS/CSS text): `scripts/{home,blog,projects,resume}.js` → `scripts/{home,blog,myspace,resume}.js`; `styles/{Blog,Projects,Resume}.css` → `styles/{Blog,MySpace,Resume}.css`
+
+## 6. `README.md`
+- File tree: `Projects/Projects.html` → `MySpace/MySpace.html`; `projects.js` → `myspace.js`; `Projects.css` → `MySpace.css`
+- Page inventory row for the Projects page: `pages/Projects/Projects.html`, `Projects.css`, `projects.js` → updated names
+- Key details: `scripts/{home,blog,projects,resume}.js` and `styles/{Blog,Projects,Resume}.css` → updated
+- "Unbuilt routes" line: `mySpace currently call notice()` → since mySpace becomes a real route, change to `All nav routes are built`
+
+## 7. Untouched (out of scope)
+- CV "Projects" section in `scripts/resume.js` / `styles/Resume.css`
+- "Personal Projects" blog category in `scripts/blog.js`
+- Historical `plan/*.md` planning documents
+
+## Verification
+- `git status` + `grep` to confirm no stale refs remain (outside `plan/` docs) for: `pages/Projects`, `Projects.html`, `scripts/projects.js`, `styles/Projects.css`
+- Open the renamed page plus each nav link to confirm routing still works (no build/test step; manual browser check)

--- a/scripts/myspace.js
+++ b/scripts/myspace.js
@@ -361,7 +361,7 @@ async function fetchGitHubIssues() {
       const title = document.createElement('h3');
       title.className = 'card-title';
       const tagSpan = document.createElement('span');
-      tagSpan.className = 'project-tag';
+      tagSpan.className = 'myspace-tag';
       tagSpan.textContent = tag;
       const titleText = document.createElement('span');
       titleText.textContent = item.title;
@@ -407,4 +407,4 @@ fetchRecentActivity();
 fetchLeetCodeStats();
 loadLatestPost();
 fetchGitHubIssues();
-initMenuToggle('#projects-container');
+initMenuToggle('#myspace-container');

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -1,37 +1,3 @@
-function notice(){ alert("Under Development!"); }
-
-function closeAllDropdowns() {
-  document.querySelectorAll('.nav-dropdown.dropdown-open').forEach(function(el) {
-    el.classList.remove('dropdown-open');
-  });
-}
-
-document.addEventListener('click', function(e) {
-  var dropdowns = document.querySelectorAll('.nav-dropdown');
-  if (!dropdowns.length) return;
-  var clickedInsideDropdown = false;
-  dropdowns.forEach(function(dropdown) {
-    if (dropdown.contains(e.target)) clickedInsideDropdown = true;
-  });
-  if (!clickedInsideDropdown) {
-    closeAllDropdowns();
-  }
-});
-
-var navDropdowns = document.querySelectorAll('.nav-dropdown > a');
-navDropdowns.forEach(function(link) {
-  link.addEventListener('click', function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    var parent = this.parentElement;
-    var wasOpen = parent.classList.contains('dropdown-open');
-    closeAllDropdowns();
-    if (!wasOpen) {
-      parent.classList.add('dropdown-open');
-    }
-  });
-});
-
 function initMenuToggle(contentSelector, restoreDisplay) {
   restoreDisplay = restoreDisplay || 'block';
   var footer = document.querySelector('footer');
@@ -45,7 +11,6 @@ function initMenuToggle(contentSelector, restoreDisplay) {
     content.style.display = "none";
     footer.style.height = "10vh";
     footer.style.bottom = "1%";
-    closeAllDropdowns();
   });
 
   footer.addEventListener('click', () => {
@@ -54,6 +19,5 @@ function initMenuToggle(contentSelector, restoreDisplay) {
     footer.style.bottom = "4%";
     header.style.display = "none";
     content.style.display = restoreDisplay;
-    closeAllDropdowns();
   });
 }

--- a/styles/Home.css
+++ b/styles/Home.css
@@ -81,51 +81,6 @@ header nav ul li a {
   color: var(--shadowColor);
 }
 
-.nav-dropdown {
-  position: relative;
-}
-
-.dropdown {
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  min-width: 140px;
-  background-color: var(--backgroundColor);
-  border: 0.15rem solid var(--borderColor);
-  border-radius: 0.3rem;
-  list-style: none;
-  padding: 0.3rem 0;
-  margin: 0.3rem 0 0;
-  z-index: 100;
-}
-
-.nav-dropdown.dropdown-open .dropdown {
-  display: block;
-}
-
-.dropdown li a {
-  display: block;
-  padding: 0.3rem 1rem;
-  font-size: 0.9rem;
-  color: var(--shadowColor);
-  text-decoration: none;
-  border-bottom: none;
-  transition: background-color 0.15s ease;
-}
-
-.dropdown li a:hover {
-  background-color: transparent;
-  border-bottom: none;
-}
-
-.dropdown li a.active {
-  background-color: var(--contentColor);
-  border: none;
-  border-radius: 0;
-  padding: 0.5rem 1rem;
-}
-
 section {
   margin: 1%;
 }
@@ -335,31 +290,6 @@ footer #footer_nav li a {
     font-size: 1.2rem;
   }
 
-  .dropdown {
-    position: static;
-    display: block;
-    border: none;
-    box-shadow: none;
-    padding: 0 0 0 1.5rem;
-    margin: 0.3rem 0;
-  }
-
-  .dropdown li a {
-    font-size: 1rem;
-    padding: 0.3rem 0;
-  }
-
-  .dropdown li a.active {
-    padding: 0.3rem 0;
-    border: none;
-    border-radius: 0;
-  }
-
-  .dropdown li a:hover {
-    background-color: transparent;
-    border-bottom: none;
-  }
-  
   footer h1{
     width: 1rem;
   }

--- a/styles/MySpace.css
+++ b/styles/MySpace.css
@@ -79,7 +79,7 @@
   opacity: 0.8;
 }
 
-.project-tag {
+.myspace-tag {
   font-size: 0.8rem;
   background-color: var(--shadowColor);
   color: var(--backgroundColor);


### PR DESCRIPTION
Closes #26

## What

Renames the Projects page stack to MySpace: the nav dropdown and files move to pages/MySpace, with all Projects-derived IDs, classes, and references updated across the site.

## Why

Previously the nav had a 'Projects' dropdown containing a 'Professional' page plus a 'mySpace' item that only triggered an 'Under Development' alert — a dead-end route. Rebranding it MySpace with a single direct nav link removes the placeholder, completes the route, and keeps naming consistent across UI, code, and docs.

## Changes

- **`pages/Projects/Projects.html` → `pages/MySpace/MySpace.html`** — renamed; updated CSS link, <title>, nav (dropdown → direct MySpace link), and Projects-derived IDs/classes (data-section, myspace-container/section/tag)
- **`scripts/projects.js` → `scripts/myspace.js`** — renamed; `project-tag` → `myspace-tag`, `initMenuToggle('#projects-container')` → `'#myspace-container'`
- **`scripts/shared.js`** — removed dead `notice()` and nav-dropdown handler code (no dropdowns remain)
- **`styles/Projects.css` → `styles/MySpace.css`** — renamed; `.project-tag` → `.myspace-tag`
- **`styles/Home.css`** — removed unreferenced `.nav-dropdown`/`.dropdown` rules and mobile overrides
- **`index.html`, `pages/Blog/Blog.html`, `pages/Resume/Resume.html`** — replaced Projects dropdown with a single MySpace link
- **`.github/workflows/update-readme.yml`, `README.md`** — updated paths and shared JS/CSS references; `mySpace` marked as a built route
- **`plan/plan_rename_projects_to_myspace.md`, `.opencode/opencode.json`** — new planning doc and opencode edit config

## How it works

1. Nav dropdowns (Projects ▸ Professional / mySpace) are replaced with a single direct MySpace link everywhere.
2. The page, its script, and its stylesheet are renamed to MySpace with all IDs/classes renamed to match.
3. Dead dropdown/notice JS in shared.js and unused dropdown CSS in Home.css are removed.
4. README and the auto-README workflow are updated so paths stay correct and the route is reported as built.

## To verify

1. Open index.html and confirm the nav shows a single MySpace link (no dropdown).
2. Click the MySpace link and confirm the page renders its collapsible sections (activity, repos, blog, LeetCode).
3. Grep the repo for `pages/Projects`, `projects.js`, and `Projects.css` to confirm no stale refs remain (ignoring plan/ docs).