### PR TITLE
Polish Professional page: banner links, fullscreen editor, mobile sidebar

### DIFF
--- a/scripts/professional.js
+++ b/scripts/professional.js
@@ -112,17 +112,7 @@ function sectionLines(lines, start) {
 
 function parseCV(text) {
   const lines = text.split('\n');
-  const data = { contact: {}, summary: '', experience: [], projects: [], education: [], skills: [] };
-  const fields = { Location: 'location', Email: 'email', LinkedIn: 'linkedin', Portfolio: 'portfolio', GitHub: 'github' };
-
-  for (let i = 1; i < lines.length && !lines[i].startsWith('## '); i++) {
-    const line = lines[i].trim();
-    for (const [key, field] of Object.entries(fields)) {
-      if (line.startsWith('**' + key + ':**')) {
-        data.contact[field] = line.split('**' + key + ':**')[1].trim();
-      }
-    }
-  }
+  const data = { summary: '', experience: [], projects: [], skills: [] };
 
   let i = 0;
   while (i < lines.length && !lines[i].startsWith('## ')) i++;
@@ -173,23 +163,6 @@ function parseCV(text) {
         const tag = afterName.split('(')[1] || '';
         const desc = content.split('--')[1] || '';
         data.projects.push({ name: name.trim(), tag: tag.trim(), desc: desc.trim() });
-      }
-      i += block.length;
-      continue;
-    }
-
-    if (section === 'Education') {
-      const block = sectionLines(lines, i + 1);
-      for (const line of block) {
-        const t = line.trim();
-        if (!t.startsWith('- ')) continue;
-        const content = t.slice(2);
-        const degree = content.split(',')[0].trim();
-        const rest = content.split(',')[1] || '';
-        const school = rest.split('(')[0].trim();
-        const cgpa = rest.includes('(') ? rest.split('(')[1].split(')')[0].trim() : '';
-        const dates = rest.includes(')') ? rest.split(')')[1].trim() : '';
-        data.education.push({ degree, school, cgpa, dates });
       }
       i += block.length;
       continue;


### PR DESCRIPTION
Closes #34

## What

Polishes the Professional portfolio page with social link buttons on the hero banner, a fullscreen editor toggle, profile hover tooltips, and comprehensive mobile responsive styling.

## Why

The Professional page needed a more polished launch banner with easy access to contact/social links. Users on mobile had no way to toggle the directory sidebar, and the hard-coded colors in CSS made future theming difficult. These changes improve usability, visual design, and maintainability.

## Changes

- **`scripts/professional.js`** — Removed dead code (contact parsing, education section), added fullscreen toggle via green titlebar dot, refactored titlebar dots into `makeBackDot` helper, added mobile activity bar with hamburger toggle for sidebar, converted skills rendering to tabbed editor panels via `createEditorPanel`, added profile tooltip system with `PROFILE_INFO` descriptions

## How it works

1. `setupEditorWindow()` creates a fullscreen-enabled editor window with `exitFullscreen()` handling both standard and WebKit fullscreen APIs. The green titlebar dot toggles fullscreen mode.
2. A new `makeBackDot()` helper abstracts the red/yellow traffic-light dots into back-controls that call `exitFullscreen()` before collapsing the banner.
3. On screens ≤720px, the directory sidebar shifts to a full-width overlay that slides in/out via `.directory.open { transform: translateX(-100%) }`, controlled by the hamburger button in the new activity bar.
4. Skills render as individual tabs created through `createEditorPanel(wrapper)`, with each skill category becoming a tab + view pair managed by `selectEditorFile()`.
5. Profile items in the profiles strip show a `PROFILE_INFO` tooltip on hover, positioned via `getBoundingClientRect()` to stay within viewport bounds.
6. All visual colors are driven by CSS variables (e.g., `--accentPrimary`, `--tokenKeyword`, `--red`), replacing hardcoded hex values throughout the stylesheet.

## To verify

1. Open `pages/Professional/Professional.html` and hover over profile roles in the strip to see tooltips with descriptions
2. Click "Launch Portfolio" and click the green titlebar dot to enter/exit fullscreen mode
3. Resize the browser to ≤720px and verify the sidebar slides out when tapping the hamburger icon in the activity bar
4. Check that all hex color values have been replaced with CSS variables by searching `Professional.css` for hex patterns