### PR TITLE
Fix modebar repositioning on resize and banner overflow

### DIFF
--- a/scripts/professional.js
+++ b/scripts/professional.js
@@ -259,6 +259,47 @@ function loadCV() {
 
 var editorWindow = null;
 
+var MOBILE_MQ = null;
+
+function refreshModebarVisibility() {
+  if (!editorWindow || !editorWindow.modebars) return;
+  var mobile = MOBILE_MQ && MOBILE_MQ.matches;
+  editorWindow.modebars.forEach(function (entry) {
+    var modebar = entry.modebar;
+    var section = entry.panel.closest('.pro-section');
+    if (mobile) {
+      var visible = !section || section.style.display !== 'none';
+      modebar.style.display = visible ? '' : 'none';
+    } else {
+      modebar.style.display = '';
+    }
+  });
+}
+
+function placeModebar(modebar) {
+  if (!editorWindow || !editorWindow.activityBar) return;
+  var mobile = MOBILE_MQ && MOBILE_MQ.matches;
+  var target = mobile ? editorWindow.activityBar : modebar.__desktopParent;
+  if (modebar.parentNode !== target) target.appendChild(modebar);
+  modebar.classList.toggle('modebar-mobile', mobile);
+}
+
+function setupModebarPlacement() {
+  if (!editorWindow || !MOBILE_MQ) return;
+  editorWindow.modebars = editorWindow.modebars || [];
+  editorWindow.main.querySelectorAll('.editor-panel').forEach(function (panel) {
+    var modebar = panel.querySelector('.editor-modebar');
+    if (!modebar) return;
+    if (!modebar.__placed) {
+      modebar.__placed = true;
+      modebar.__desktopParent = modebar.parentNode;
+      editorWindow.modebars.push({ modebar: modebar, panel: panel });
+    }
+    placeModebar(modebar);
+  });
+  refreshModebarVisibility();
+}
+
 function exitFullscreen() {
   if (document.fullscreenElement) {
     if (document.exitFullscreen) document.exitFullscreen().catch(function () {});
@@ -376,7 +417,7 @@ function setupEditorWindow() {
   container.appendChild(body);
   container.appendChild(statusbar);
 
-  editorWindow = { sidebar: sidebar, tree: tree, main: main, entries: [] };
+  editorWindow = { sidebar: sidebar, tree: tree, main: main, entries: [], activityBar: activityBar };
   return editorWindow;
 }
 
@@ -432,6 +473,7 @@ function activateSection(sectionEl, item) {
   });
   sectionEl.style.display = 'block';
   setActiveTreeItem(item);
+  refreshModebarVisibility();
 }
 
 function registerDirectoryEntry(title, sectionEl, item) {
@@ -553,6 +595,8 @@ function renderProfessional(data) {
   if (exp.tabRefs[0] && exp.tabRefs[0].item) {
     activateSection(expSection, exp.tabRefs[0].item);
   }
+
+  setupModebarPlacement();
 }
 
 function renderSection(title, contentEl) {
@@ -1083,6 +1127,17 @@ function selectEditorFile(editor, tab, view) {
     });
   }
 })();
+
+MOBILE_MQ = window.matchMedia('(max-width: 720px)');
+if (MOBILE_MQ.addEventListener) {
+  MOBILE_MQ.addEventListener('change', function () {
+    setupModebarPlacement();
+  });
+} else {
+  MOBILE_MQ.addListener(function () {
+    setupModebarPlacement();
+  });
+}
 
 loadCV();
 

--- a/scripts/professional.js
+++ b/scripts/professional.js
@@ -300,6 +300,13 @@ function setupModebarPlacement() {
   refreshModebarVisibility();
 }
 
+function showBanner() {
+  const banner = document.getElementById('launch-banner');
+  if (!banner) return;
+  banner.classList.remove('launched');
+  if (banner.__setEyesVisible) banner.__setEyesVisible(true);
+}
+
 function exitFullscreen() {
   if (document.fullscreenElement) {
     if (document.exitFullscreen) document.exitFullscreen().catch(function () {});
@@ -324,8 +331,7 @@ function setupEditorWindow() {
     dot.setAttribute('aria-label', label);
     dot.addEventListener('click', function () {
       exitFullscreen();
-      const banner = document.getElementById('launch-banner');
-      if (banner) banner.classList.remove('launched');
+      showBanner();
       this.blur();
     });
     return dot;
@@ -396,8 +402,7 @@ function setupEditorWindow() {
   backBtn.title = 'Back';
   backBtn.addEventListener('click', function () {
     exitFullscreen();
-    const banner = document.getElementById('launch-banner');
-    if (banner) banner.classList.remove('launched');
+    showBanner();
   });
   titlebar.appendChild(backBtn);
 
@@ -1116,14 +1121,18 @@ function selectEditorFile(editor, tab, view) {
     });
   });
 
+  banner.__setEyesVisible = function (visible) {
+    eyes.forEach(function (eye) {
+      eye.sclera.style.display = visible ? '' : 'none';
+      eye.pupil.style.display = visible ? '' : 'none';
+      eye.lid.style.display = visible ? '' : 'none';
+    });
+  };
+
   var launchBtn = document.getElementById('launch-btn');
   if (launchBtn) {
     launchBtn.addEventListener('click', function () {
-      eyes.forEach(function (eye) {
-        eye.sclera.style.display = 'none';
-        eye.pupil.style.display = 'none';
-        eye.lid.style.display = 'none';
-      });
+      banner.__setEyesVisible(false);
     });
   }
 })();

--- a/styles/Professional.css
+++ b/styles/Professional.css
@@ -53,12 +53,16 @@ body.pro-page {
   left: 0;
   width: 100vw;
   min-height: 100vh;
+  min-height: 100dvh;
   z-index: 2000;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   background-color: var(--editorBg);
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   transition: transform 0.6s ease;
 }
 
@@ -67,34 +71,44 @@ body.pro-page {
 }
 
 .launch-banner .hero-block {
-  margin: 3rem 0;
+  margin: clamp(1.5rem, 4vh, 3rem) 0;
 }
 
 .launch-banner .profiles-block {
   width: 100%;
-  margin: 2.5rem 0;
+  margin: clamp(1rem, 3vh, 2.5rem) 0;
 }
 
 .launch-banner .summary-block {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 2.5rem 0;
+  margin: clamp(1rem, 3vh, 2.5rem) 0;
+  padding-inline: 1rem;
 }
 
 .launch-banner .links-block {
-  margin: 2.5rem 0;
+  margin: clamp(1rem, 3vh, 2.5rem) 0;
+}
+
+/* Centered when there's room; scroll-safe so top isn't clipped on short screens */
+.launch-banner>*:first-child {
+  margin-top: auto;
+}
+
+.launch-banner>*:last-child {
+  margin-bottom: auto;
 }
 
 .launch-btn {
   font-family: var(--poppins);
-  font-size: 1.5rem;
+  font-size: clamp(1.1rem, 2.5vw, 1.5rem);
   font-weight: 700;
   color: var(--accentDark);
   background-color: var(--accentPrimary);
   border: none;
   border-radius: 0.4rem;
-  padding: 1.25rem 2rem 1.25rem 2rem;
+  padding: clamp(0.9rem, 2vh, 1.25rem) clamp(1.25rem, 4vw, 2rem);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -118,8 +132,13 @@ body.pro-page {
 
 .launch-banner .banner-links {
   display: flex;
-  gap: 4rem;
+  flex-wrap: wrap;
+  gap: clamp(1.5rem, 5vw, 4rem);
   align-items: center;
+  justify-content: center;
+  padding-inline: 1rem;
+  box-sizing: border-box;
+  max-width: 100%;
 }
 
 .launch-banner .banner-links a {
@@ -182,7 +201,7 @@ body.pro-page {
 
 .launch-banner h1 {
   font-family: var(--headings);
-  font-size: 8rem;
+  font-size: clamp(2.5rem, 10vw, 8rem);
   margin-bottom: 0;
   margin-top: 0;
   font-weight: 500;
@@ -193,7 +212,7 @@ body.pro-page {
 
 .launch-banner .role {
   font-family: var(--poppins);
-  font-size: 2.5rem;
+  font-size: clamp(1.2rem, 4vw, 2.5rem);
   font-weight: 500;
   color: var(--accentPrimary);
   margin: 0;
@@ -202,12 +221,12 @@ body.pro-page {
 
 .launch-banner .profiles {
   font-family: var(--poppins);
-  font-size: 1.5rem;
+  font-size: clamp(1rem, 3vw, 1.5rem);
   font-weight: 500;
   color: var(--editorBg);
   margin: 0;
-  height: 3rem;
-  line-height: 3rem;
+  height: clamp(2.5rem, 7vh, 3rem);
+  line-height: clamp(2.5rem, 7vh, 3rem);
   overflow: hidden;
   position: relative;
   width: 100%;
@@ -246,8 +265,8 @@ body.pro-page {
 
 .profiles-item {
   flex: 0 0 auto;
-  height: 3rem;
-  line-height: 3rem;
+  height: clamp(2.5rem, 7vh, 3rem);
+  line-height: clamp(2.5rem, 7vh, 3rem);
   white-space: nowrap;
   display: flex;
   align-items: center;
@@ -304,13 +323,15 @@ body.pro-page {
 
 .launch-banner .hero-summary {
   font-family: var(--poppins);
-  font-size: 1.5rem;
+  font-size: clamp(0.9rem, 2.5vw, 1.5rem);
   color: var(--editorMuted);
   line-height: 1.6;
   margin: 0;
   max-width: 100ch;
-  margin-bottom: 2rem;
+  width: 100%;
+  margin-bottom: clamp(1rem, 3vh, 2rem);
   text-align: center;
+  box-sizing: border-box;
 }
 
 .launch-banner h1 {
@@ -808,12 +829,12 @@ body.pro-page .page-container {
 
 .mode-btn {
   font-family: var(--poppins);
-  font-size: 0.82rem;
+  font-size: 1rem;
   font-weight: 600;
   color: var(--editorMuted);
   background: none;
   border: none;
-  padding: 0.35rem 0.7rem;
+  padding: 0.4rem 0.8rem;
   cursor: pointer;
   border-radius: 0.25rem;
   transition: background-color 0.15s ease, color 0.15s ease;
@@ -1327,15 +1348,10 @@ body.pro-page footer #footer_nav {
 /* Responsive: max-width 720px */
 @media (max-width: 720px) {
   .launch-banner {
-    justify-content: flex-start;
     box-sizing: border-box;
     padding: 2.5rem 0;
     height: 100vh;
     height: 100dvh;
-    overflow-y: auto;
-    overflow-x: hidden;
-    overscroll-behavior: contain;
-    -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
   }
 
@@ -1345,25 +1361,26 @@ body.pro-page footer #footer_nav {
     flex-shrink: 0;
   }
 
-  .launch-banner h1 {
-    font-size: clamp(2.25rem, 24vw, 4rem);
-    padding-inline: 0.75rem;
+  .launch-banner .hero-block,
+  .launch-banner .profiles-block,
+  .launch-banner .summary-block,
+  .launch-banner .links-block {
+    width: 100%;
+    box-sizing: border-box;
+    padding-inline: 1.25rem;
   }
 
-  .launch-banner .role {
-    font-size: clamp(1.1rem, 6vw, 1.75rem);
+  .launch-banner .banner-links {
+    flex-wrap: wrap;
+    gap: 1.5rem;
+  }
+
+  .launch-banner h1 {
     padding-inline: 0.75rem;
   }
 
   .launch-banner .profiles {
-    font-size: 1rem;
-  }
-
-  .launch-banner .hero-summary {
-    font-size: clamp(0.8rem, 4vw, 1rem);
-    max-width: 100%;
-    padding-inline: 1.25rem;
-    text-align: center;
+    padding-inline: 0;
   }
 
   .editor-tab {
@@ -1431,13 +1448,12 @@ body.pro-page footer #footer_nav {
     white-space: normal;
   }
 
-  .editor-modebar {
-    padding: 0.25rem 0.4rem;
+  .editor-tabsbar .editor-modebar {
+    display: none;
   }
 
   .mode-btn {
-    font-size: 0.7rem;
-    padding: 0.25rem 0.5rem;
+    padding: 0.4rem 0.7rem;
   }
 
   /* Sidebar toggle becomes a slim header row so content can use the full width */
@@ -1458,6 +1474,13 @@ body.pro-page footer #footer_nav {
 
   .activity-bar .directory-toggle {
     padding: 0;
+  }
+
+  .activity-bar .editor-modebar {
+    display: flex;
+    margin-left: auto;
+    flex: 0 0 auto;
+    padding: 0.1rem 0 0.1rem 0.5rem;
   }
 
   .editor-content {


### PR DESCRIPTION
Closes #42

## What
Fixes modebars not repositioning when resizing across the 720px breakpoint, makes the launch banner scroll-safe on short screens, and restores the animated banner eyes after returning from the editor.

## Why
Modebars (Preview/Source toggle) only moved on initial load, so after resizing they got stuck in the wrong container — hidden on mobile or stray elements in the activity bar on desktop. The banner also clipped content on short viewports due to fixed sizing, and the cursor-tracking eyes stayed hidden after clicking back to the banner.

## Changes

- **`scripts/professional.js`** — Move `placeModebar` outside the `__placed` guard so modebars reposition on every media query change; add `activityBar` to `editorWindow` and hook up the mobile matchMedia listener; refactor eye visibility into `banner.__setEyesVisible` and add a `showBanner` helper that restores the eyes when returning from the editor
- **`styles/Professional.css`** — Replace fixed banner dimensions with clamp-based values, add scroll-safe auto margins, and style the mobile activity-bar modebar while hiding the tabsbar variant

## How it works

1. `setupModebarPlacement` discovers modebars once, caching their desktop parent
2. `placeModebar` moves each modebar to the activity bar on mobile or back on desktop
3. A `matchMedia('(max-width: 720px)')` change listener re-runs placement on every resize
4. `refreshModebarVisibility` hides inactive modebars when sections are switched
5. `showBanner` removes the launched class and re-shows the eyes on the red/yellow dots or Back button

## To verify

1. Load the page on desktop, resize under 720px — the Preview/Source toggle should move and remain visible
2. Resize back above 720px — the toggle returns to its tab
3. Click launch, then Back — the cursor-tracking eyes should render again on the banner
4. On a short mobile screen, confirm the banner scrolls without clipping the top