### PR TITLE
Enforce repo norms and evolve the professional page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# opencode.md — Project Norms
+
+Static portfolio site. Plain HTML + external vanilla JS/CSS. **No build system, no package manager, no dependencies** — files are served as-is via GitHub Pages. Preview locally by opening `index.html` in a browser.
+
+## File structure
+
+| Asset | Convention | Example |
+|---|---|---|
+| Page | `pages/<Name>/<Name>.html` (PascalCase, matching folder) | `pages/Blog/Blog.html` |
+| Page CSS | `styles/<Name>.css` (PascalCase, matching page) | `styles/Blog.css` |
+| Page JS | `scripts/<name>.js` (lowercase, matching page) | `scripts/blog.js` |
+| Shared JS | `scripts/shared.js` | — |
+| Shared theme/components | `styles/styles.css` (custom properties + shared classes) | — |
+| Blog post | `src/Blogs/NN-slug-title.md` (zero-padded number + kebab slug) | `08-legacy-stacks.md` |
+| Content source | `src/cv.md` (canonical resume), `src/Blogs/posts.json` (blog manifest) | — |
+
+## HTML
+
+- Use **semantic** HTML (header, nav, section, footer, etc.).
+- Use **relative paths only** (`./`, `../`, `../../`) — never absolute paths.
+- Load order on sub-pages: shared `styles/styles.css` first, then page CSS; `scripts/shared.js` before the page script.
+- The `<header>` (brand + nav) and footer social-SVG blocks are **duplicated verbatim across every page** — apply any nav/footer change to all pages. `.active` marks the current page's nav link. Sub-pages use `<body class="sub-page">`; `index.html` does not.
+- Attribute values use double quotes.
+
+## JavaScript
+
+- **`const` by default**; `let` only when reassignment is required. Never use `var` in new code.
+- **JSDoc-style comment on every function** (top-level and nested callbacks).
+  ```js
+  /**
+   * Renders the list of posts grouped by category.
+   */
+  function renderBlogList() { ... }
+  ```
+- Use single quotes for strings.
+- Cross-page logic goes in `scripts/shared.js`; page-specific logic in the page's own script (e.g. `scripts/blog.js`). Never duplicate shared helpers per page.
+- Use `fetch()` with relative paths; the site must work when opened from `file://` and GitHub Pages.
+
+## CSS
+
+- **Never hardcode colors or typography.** All colors/fonts come from CSS custom properties in `:root` of `styles/styles.css` (`--borderColor`, `--backgroundColor`, `--shadowColor`, `--contentColor`, `--headings`, `--poppins`, etc.).
+- **Reuse existing component classes** (`.card`, `.section-heading`, `.skill-item`, `.stat-card`) rather than inventing new ones.
+- Shared/cross-page styles extend `styles/styles.css`; page CSS files hold only page-specific layout.
+- Responsive breakpoint convention: **720px**.
+- Selectors use lowercase kebab-case (`.post-grid`, `.card-title`).
+
+## Verification
+
+- No linter, test suite, or build step exists.
+- Run `node --check` on any modified JS file to catch syntax errors.
+- Manually verify by opening the affected page(s) in a browser.
+
+## Out of scope
+
+- **Git/branch/commit workflow**: handled by the user.
+- **README.md**: protected — never edit.
+- **Content publishing (blogs, CV)**: use the `quick-blog` skill; do not reinvent its workflow.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="./styles/styles.css"/>
   <link rel="stylesheet" href="./styles/Home.css"/>
   <title>Ujjwal Verma</title>
 </head>

--- a/pages/Blog/Blog.html
+++ b/pages/Blog/Blog.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/styles.css"/>
+  <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/Blog.css"/>
   <title>Blog - Ujjwal Verma</title>
 </head>

--- a/pages/MySpace/MySpace.html
+++ b/pages/MySpace/MySpace.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/styles.css"/>
+  <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/MySpace.css"/>
   <title>MySpace - Ujjwal Verma</title>
 </head>

--- a/pages/Professional/Professional.html
+++ b/pages/Professional/Professional.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/styles.css"/>
+  <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/Professional.css"/>
   <title>Professional - Ujjwal Verma</title>
 </head>
@@ -56,6 +56,7 @@
     </div>
   </section>
 
+  <script src="../../scripts/shared.js"></script>
   <script src="../../scripts/professional.js"></script>
 </body>
 </html>

--- a/pages/Resume/Resume.html
+++ b/pages/Resume/Resume.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/styles.css"/>
+  <link rel="stylesheet" href="../../styles/Home.css"/>
   <link rel="stylesheet" href="../../styles/Resume.css"/>
   <title>Resume - Ujjwal Verma</title>
 </head>

--- a/scripts/blog.js
+++ b/scripts/blog.js
@@ -1,6 +1,16 @@
+/**
+ * Blog post categories, shown as collapsible sections in order.
+ */
 const categories = ['Deloitte', 'Personal Projects', 'Research'];
+
+/**
+ * Parsed posts loaded from the manifest.
+ */
 const posts = [];
 
+/**
+ * Loads all posts from the manifest and parses each markdown file.
+ */
 async function loadPosts() {
   try {
     const res = await fetch('../../src/Blogs/posts.json');
@@ -31,28 +41,9 @@ async function loadPosts() {
   }
 }
 
-function parsePostHeaders(text) {
-  const meta = {};
-  const lines = text.split('\n');
-  for (const line of lines) {
-    if (line.startsWith('## Paragraphs')) break;
-    const match = line.match(/^## (\w+):\s*(.+)/);
-    if (match) {
-      meta[match[1].toLowerCase()] = match[2].trim();
-    }
-  }
-  return meta;
-}
-
-function parsePostBody(text) {
-  const lines = text.split('\n');
-  const bodyStart = lines.findIndex(l => l.startsWith('## Paragraphs'));
-  if (bodyStart === -1) return [];
-  return lines.slice(bodyStart + 1)
-    .filter(line => line.startsWith('- '))
-    .map(line => line.slice(2).trim());
-}
-
+/**
+ * Renders the list of posts grouped by category.
+ */
 function renderBlogList() {
   const container = document.getElementById('blog-list');
   container.innerHTML = '';
@@ -109,6 +100,11 @@ function renderBlogList() {
   });
 }
 
+/**
+ * Toggles a blog category section open/closed.
+ *
+ * @param {HTMLElement} header The section heading that was clicked.
+ */
 function toggleBlogSection(header) {
   const content = header.nextElementSibling;
   const icon = header.querySelector('.toggle-icon');
@@ -122,6 +118,11 @@ function toggleBlogSection(header) {
   header.classList.toggle('active');
 }
 
+/**
+ * Shows a single post's full view by index.
+ *
+ * @param {number} index Index of the post in the posts array.
+ */
 function showPost(index) {
   const post = posts[index];
   document.getElementById('blog-list').style.display = 'none';
@@ -146,6 +147,9 @@ function showPost(index) {
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
+/**
+ * Returns to the post list and clears the post hash from the URL.
+ */
 function showBlogList() {
   document.getElementById('post-view').style.display = 'none';
   document.getElementById('blog-list').style.removeProperty('display');
@@ -153,12 +157,15 @@ function showBlogList() {
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
+/**
+ * Loads posts, renders the list, then honors an incoming `#post-N` hash.
+ */
 loadPosts().then(() => {
   renderBlogList();
 
-  var hash = window.location.hash;
+  const hash = window.location.hash;
   if (hash && hash.startsWith('#post-')) {
-    var idx = parseInt(hash.replace('#post-', ''), 10);
+    const idx = parseInt(hash.replace('#post-', ''), 10);
     if (!isNaN(idx) && idx >= 0 && idx < posts.length) {
       showPost(idx);
     }

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -1,17 +1,25 @@
+/**
+ * Current local hour, used to pick the greeting.
+ */
 const dateObj = new Date();
 const hour = dateObj.getHours();
 
+/**
+ * Returns a time-appropriate greeting message.
+ *
+ * @returns {string} Greeting text for the current hour.
+ */
 function setGreet() {
   if (6 <= hour && hour < 12) {
-    return "Good Morning!"
+    return 'Good Morning!';
   } else if (12 <= hour && hour < 17) {
-    return "Good Afternoon!"
+    return 'Good Afternoon!';
   } else if (17 <= hour && hour < 22) {
-    return "Good Evening!"
+    return 'Good Evening!';
   } else {
-    return "Good Evening, You should be in bed by now!"
+    return 'Good Evening, You should be in bed by now!';
   }
 }
 
-document.getElementById("salutation").innerHTML = setGreet();
+document.getElementById('salutation').innerHTML = setGreet();
 initMenuToggle('#hero', 'flex');

--- a/scripts/myspace.js
+++ b/scripts/myspace.js
@@ -1,24 +1,14 @@
-function toggleSection(header) {
-  const content = header.nextElementSibling;
-  const icon = header.querySelector('.toggle-icon');
-  if (content.style.display === 'none') {
-    content.style.display = '';
-    icon.textContent = '-';
-  } else {
-    content.style.display = 'none';
-    icon.textContent = '+';
-  }
-  header.classList.toggle('active');
-}
-
+/**
+ * In-memory cache TTL (30 minutes) for external API responses.
+ */
 const CACHE_TTL = 30 * 60 * 1000;
 
-function escapeHtml(str) {
-  return String(str ?? '').replace(/[&<>"']/g, (c) => ({
-    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-  }[c]));
-}
-
+/**
+ * Renders the LeetCode activity bar chart into the submissions card.
+ *
+ * @param {Object|string} submissionCalendar Day-timestamp to submissions map (or JSON string).
+ * @returns {boolean} Whether activity rendered successfully.
+ */
 function renderLeetCodeActivity(submissionCalendar) {
   const container = document.getElementById('lc-activity');
   if (!container) return false;
@@ -91,11 +81,17 @@ function renderLeetCodeActivity(submissionCalendar) {
   return true;
 }
 
+/**
+ * Fetches and renders the LeetCode submission activity heatmap.
+ */
 async function fetchLeetCodeActivity() {
   const container = document.getElementById('lc-activity');
   const card = document.getElementById('lc-submissions-card');
   if (!container) return;
 
+  /**
+   * Shows the loading state inside the activity card.
+   */
   const showLoading = () => {
     if (card) card.style.display = 'block';
     container.innerHTML = `
@@ -105,6 +101,11 @@ async function fetchLeetCodeActivity() {
       </div>`;
   };
 
+  /**
+   * Shows an error state inside the activity card.
+   *
+   * @param {string} message Error text to display.
+   */
   const showError = (message) => {
     if (card) card.style.display = 'block';
     container.innerHTML = `
@@ -139,6 +140,11 @@ async function fetchLeetCodeActivity() {
   }
 }
 
+/**
+ * Renders the recent LeetCode submissions list.
+ *
+ * @param {Object[]} submissions Recent submission objects.
+ */
 function renderRecentSubmissions(submissions) {
   const list = document.getElementById('lc-submissions');
   if (!list || !Array.isArray(submissions) || submissions.length === 0) return;
@@ -168,6 +174,9 @@ function renderRecentSubmissions(submissions) {
   list.innerHTML = items;
 }
 
+/**
+ * Fetches and renders recent LeetCode submissions.
+ */
 async function fetchRecentSubmissions() {
   const list = document.getElementById('lc-submissions');
   if (!list) return;
@@ -185,6 +194,12 @@ async function fetchRecentSubmissions() {
   }
 }
 
+/**
+ * Fetches JSON with a localStorage cache, storing each URL for CACHE_TTL milliseconds.
+ *
+ * @param {string} url Endpoint to fetch.
+ * @returns {Promise<Object>} The parsed JSON response.
+ */
 async function cachedFetch(url) {
   const cacheKey = 'gh_cache_' + url;
   const cached = localStorage.getItem(cacheKey);
@@ -199,6 +214,9 @@ async function cachedFetch(url) {
   return data;
 }
 
+/**
+ * Fetches and renders the user's most recently updated GitHub repositories.
+ */
 async function fetchGitHubStats() {
   try {
     const repos = await cachedFetch('https://api.github.com/users/ujjuboi/repos?sort=updated&per_page=6');
@@ -206,7 +224,13 @@ async function fetchGitHubStats() {
 
     const grid = document.getElementById('github-repos-grid');
 
-    const cards = await Promise.all(repos.map(async (repo) => {
+    /**
+     * Builds one repository card, preferring its README's first paragraph as the description.
+     *
+     * @param {Object} repo Repository object from the GitHub API.
+     * @returns {Promise<HTMLElement>} The completed card element.
+     */
+    const buildCard = async (repo) => {
       let description = repo.description || '';
       try {
         const readmeData = await cachedFetch(`https://api.github.com/repos/ujjuboi/${repo.name}/readme`);
@@ -228,7 +252,9 @@ async function fetchGitHubStats() {
         <span class="repo-card-lang">${repo.language || ''}</span>
       `;
       return card;
-    }));
+    };
+
+    const cards = await Promise.all(repos.map(buildCard));
 
     cards.forEach(c => grid.appendChild(c));
     document.getElementById('github-loading').style.display = 'none';
@@ -240,9 +266,15 @@ async function fetchGitHubStats() {
   }
 }
 
+/**
+ * Whether recent-activity widgets have loaded data successfully.
+ */
 let recentActivityOk = false;
 let gitHubIssuesOk = false;
 
+/**
+ * Shows the activity fallback message only when every activity widget failed.
+ */
 function syncActivityFallback() {
   const fallback = document.getElementById('activity-fallback');
   if (!recentActivityOk && !gitHubIssuesOk) {
@@ -252,6 +284,9 @@ function syncActivityFallback() {
   }
 }
 
+/**
+ * Fetches the most recent commit authored by the user and displays it as the current activity.
+ */
 async function fetchRecentActivity() {
   try {
     const repos = await cachedFetch('https://api.github.com/users/ujjuboi/repos?sort=updated&per_page=1');
@@ -281,6 +316,9 @@ async function fetchRecentActivity() {
   }
 }
 
+/**
+ * Fetches and renders the LeetCode solve statistics and recent activity.
+ */
 async function fetchLeetCodeStats() {
   try {
     const data = await cachedFetch('https://leetcode-stats.tashif.codes/ujjuboi');
@@ -310,6 +348,9 @@ async function fetchLeetCodeStats() {
   }
 }
 
+/**
+ * Loads the newest blog post from the manifest and shows it in the research card.
+ */
 async function loadLatestPost() {
   try {
     const manifestRes = await fetch('../../src/Blogs/posts.json');
@@ -320,12 +361,7 @@ async function loadLatestPost() {
     const mdRes = await fetch('../../src/Blogs/' + filenames[0]);
     if (!mdRes.ok) throw new Error('Failed to fetch ' + filenames[0]);
     const text = await mdRes.text();
-    const meta = {};
-    for (const line of text.split('\n')) {
-      if (line.startsWith('## Paragraphs')) break;
-      const match = line.match(/^## (\w+):\s*(.+)/);
-      if (match) meta[match[1].toLowerCase()] = match[2].trim();
-    }
+    const meta = parsePostHeaders(text);
 
     document.getElementById('research-banner').src = meta.banner || '';
     document.getElementById('research-banner').alt = meta.title || '';
@@ -339,6 +375,9 @@ async function loadLatestPost() {
   }
 }
 
+/**
+ * Fetches and renders the user's open issues and pull requests.
+ */
 async function fetchGitHubIssues() {
   try {
     const data = await cachedFetch('https://api.github.com/search/issues?q=author:ujjuboi+state:open&sort=created&order=desc&per_page=10');

--- a/scripts/professional.js
+++ b/scripts/professional.js
@@ -1,33 +1,17 @@
-function escapeHtml(text) {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}
-
-function mdInline(text) {
-  let html = escapeHtml(String(text || ''));
-  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (match, label, url) {
-    const trimmed = url.trim();
-    const scheme = trimmed.match(/^([a-z][a-z0-9+.-]*):/i);
-    if (scheme && ['http', 'https', 'mailto', '#'].indexOf(scheme[1].toLowerCase()) === -1) {
-      return match;
-    }
-    return '<a href="' + escapeHtml(trimmed) + '" target="_blank" rel="noopener">' + label + '</a>';
-  });
-  html = html.replace(/\*\*\*([^*]+)\*\*\*/g, '<strong><em>$1</em></strong>');
-  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-  html = html.replace(/(^|[^*])\*([^*]+)\*/g, function (match, pre, italic) {
-    return pre + '<em>' + italic + '</em>';
-  });
-  return html;
-}
-
+/**
+ * Converts a block of markdown (headings, lists, quotes, rulers) into HTML.
+ *
+ * @param {string} text Markdown source to render.
+ * @returns {string} Rendered HTML.
+ */
 function mdBlock(text) {
   const lines = String(text || '').split('\n');
   let html = '';
   const stack = [];
 
+  /**
+   * Closes every list element still open on the tag stack.
+   */
   function closeAll() {
     while (stack.length) {
       const tag = stack.pop();
@@ -88,187 +72,35 @@ function mdBlock(text) {
   return html;
 }
 
+/**
+ * Replaces the professional container with a loading placeholder.
+ */
 function showLoading() {
   const container = document.getElementById('pro-container');
   container.innerHTML = '<p class="loading-placeholder">Loading<span class="dot dot1">.</span><span class="dot dot2">.</span><span class="dot dot3">.</span></p>';
 }
 
+/**
+ * Replaces the professional container with an error message.
+ *
+ * @param {string} message Error text to display.
+ */
 function showError(message) {
   const container = document.getElementById('pro-container');
   container.innerHTML = '<p class="error-message">' + escapeHtml(message) + '</p>';
 }
 
-function nextNonBlank(lines, start) {
-  let j = start;
-  while (j < lines.length && lines[j].trim() === '') j++;
-  return j;
-}
-
-function sectionLines(lines, start) {
-  const result = [];
-  let j = start;
-  while (j < lines.length && !lines[j].startsWith('## ')) {
-    result.push(lines[j]);
-    j++;
-  }
-  return result;
-}
-
-var SORT_MONTHS = { jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6, jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12 };
-var SORT_MONTH_LABELS = ['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-function parseStartSortKey(dateStr) {
-  const m = String(dateStr || '').trim().match(/^([A-Za-z]+)\s+(\d{4})/);
-  if (!m) return 0;
-  const mon = SORT_MONTHS[m[1].toLowerCase().slice(0, 3)];
-  if (!mon) return 0;
-  return parseInt(m[2], 10) * 100 + mon;
-}
-
-function sortKeyToLabel(key) {
-  if (!key) return '';
-  const year = Math.floor(key / 100);
-  const mon = key % 100;
-  return SORT_MONTH_LABELS[mon] ? SORT_MONTH_LABELS[mon] + ' ' + year : '';
-}
-
-function parseCV(text) {
-  const lines = text.split('\n');
-  const data = { summary: '', experience: [], projects: [], skills: [] };
-
-  let i = 0;
-  while (i < lines.length && !lines[i].startsWith('## ')) i++;
-
-  while (i < lines.length) {
-    const section = lines[i].replace(/^## /, '').trim();
-
-    if (section === 'Professional Summary') {
-      i = nextNonBlank(lines, i + 1);
-      const end = sectionLines(lines, i);
-      data.summary = end.filter(l => l.trim()).join(' ');
-      i += end.length;
-      continue;
-    }
-
-    if (section === 'Work Experience') {
-      const block = sectionLines(lines, i + 1);
-      let job = null;
-      for (const line of block) {
-        if (line.startsWith('### ')) {
-          if (job) data.experience.push(job);
-          job = { company: line.replace(/^### /, '').trim(), role: '', date: '', bullets: [] };
-        } else if (job) {
-          const t = line.trim();
-          if (t === '') continue;
-          if (t.startsWith('**') && t.endsWith('**') && !job.role) {
-            job.role = t.slice(2, -2);
-          } else if (/^#{3,6}\s/.test(t)) {
-            job.bullets.push({
-              kind: 'heading',
-              level: t.match(/^#+/)[0].length,
-              text: t.replace(/^#+\s*/, '')
-            });
-          } else if (/^[-+*]\s/.test(t) && line !== t) {
-            const last = job.bullets[job.bullets.length - 1];
-            if (last && last.kind === 'bullet') {
-              last.sub.push(t.replace(/^[-+*]\s*/, ''));
-            }
-          } else if (t.startsWith('- ')) {
-            job.bullets.push({ kind: 'bullet', text: t.slice(2), sub: [] });
-          } else if (/^>\s*\[([^\]]+)\]\(([^)]+)\)/.test(t)) {
-            const m = t.match(/^>\s*\[([^\]]+)\]\(([^)]+)\)/);
-            job.readMore = { label: m[1], url: m[2] };
-          } else if (/^!\[[^\]]*\]\(([^)]+)\)/.test(t)) {
-            const m = t.match(/^!\[[^\]]*\]\(([^)]+)\)/);
-            job.banner = m[1].trim();
-          } else if (t && !job.date) {
-            job.date = t;
-            job.sortKey = parseStartSortKey(t);
-          }
-        }
-      }
-      if (job) data.experience.push(job);
-      i += block.length;
-      continue;
-    }
-
-    if (section === 'Projects') {
-      const block = sectionLines(lines, i + 1);
-      let proj = null;
-      for (const line of block) {
-        const t = line.trim();
-        if (/^>\s*\[([^\]]+)\]\(([^)]+)\)/.test(t)) {
-          const m = t.match(/^>\s*\[([^\]]+)\]\(([^)]+)\)/);
-          if (proj) proj.readMore = { label: m[1], url: m[2] };
-          continue;
-        }
-        if (/^!\[[^\]]*\]\(([^)]+)\)/.test(t)) {
-          const m = t.match(/^!\[[^\]]*\]\(([^)]+)\)/);
-          if (proj) proj.banner = m[1].trim();
-          continue;
-        }
-        if (!t.startsWith('- ')) continue;
-        const content = t.slice(2);
-        const name = content.split('**')[1] || '';
-        const afterName = content.split(')')[0] || '';
-        const tag = afterName.split('(')[1] || '';
-        const desc = content.split('--')[1] || '';
-        proj = { name: name.trim(), tag: tag.trim(), desc: desc.trim() };
-        data.projects.push(proj);
-      }
-      i += block.length;
-      continue;
-    }
-
-    if (section === 'Skills') {
-      const block = sectionLines(lines, i + 1);
-      for (const line of block) {
-        const t = line.trim();
-        if (!t.startsWith('- ')) continue;
-        const content = t.slice(2);
-        const category = (content.split('**')[1] || '').replace(/:$/, '');
-        const items = (content.split(':**')[1] || '').split(',').map(s => s.trim());
-        data.skills.push({ category, items });
-      }
-      i += block.length;
-      continue;
-    }
-
-    i++;
-  }
-
-  return data;
-}
-
-function loadCV() {
-  showLoading();
-  fetch('../../src/cv.md')
-    .then(res => {
-      if (!res.ok) throw new Error('Failed to fetch CV');
-      return res.text();
-    })
-    .then(text => {
-      const data = parseCV(text);
-      renderProfessional(data);
-    })
-    .catch(e => {
-      console.error('Error loading CV:', e);
-      showError('Failed to load CV data.');
-    });
-}
-
-var editorWindow = null;
-
-var MOBILE_MQ = null;
-
+/**
+ * Toggles whether editor modebars are shown, hiding them when their section is collapsed on mobile.
+ */
 function refreshModebarVisibility() {
   if (!editorWindow || !editorWindow.modebars) return;
-  var mobile = MOBILE_MQ && MOBILE_MQ.matches;
+  const mobile = MOBILE_MQ && MOBILE_MQ.matches;
   editorWindow.modebars.forEach(function (entry) {
-    var modebar = entry.modebar;
-    var section = entry.panel.closest('.pro-section');
+    const modebar = entry.modebar;
+    const section = entry.panel.closest('.pro-section');
     if (mobile) {
-      var visible = !section || section.style.display !== 'none';
+      const visible = !section || section.style.display !== 'none';
       modebar.style.display = visible ? '' : 'none';
     } else {
       modebar.style.display = '';
@@ -276,19 +108,27 @@ function refreshModebarVisibility() {
   });
 }
 
+/**
+ * Moves a modebar into the activity bar on mobile, or back to its desktop parent.
+ *
+ * @param {HTMLElement} modebar The modebar element to place.
+ */
 function placeModebar(modebar) {
   if (!editorWindow || !editorWindow.activityBar) return;
-  var mobile = MOBILE_MQ && MOBILE_MQ.matches;
-  var target = mobile ? editorWindow.activityBar : modebar.__desktopParent;
+  const mobile = MOBILE_MQ && MOBILE_MQ.matches;
+  const target = mobile ? editorWindow.activityBar : modebar.__desktopParent;
   if (modebar.parentNode !== target) target.appendChild(modebar);
   modebar.classList.toggle('modebar-mobile', mobile);
 }
 
+/**
+ * Locates every editor modebar and records its desktop parent before placing it.
+ */
 function setupModebarPlacement() {
   if (!editorWindow || !MOBILE_MQ) return;
   editorWindow.modebars = editorWindow.modebars || [];
   editorWindow.main.querySelectorAll('.editor-panel').forEach(function (panel) {
-    var modebar = panel.querySelector('.editor-modebar');
+    const modebar = panel.querySelector('.editor-modebar');
     if (!modebar) return;
     if (!modebar.__placed) {
       modebar.__placed = true;
@@ -300,6 +140,9 @@ function setupModebarPlacement() {
   refreshModebarVisibility();
 }
 
+/**
+ * Restores the launch banner overlay to its visible, unlaunched state.
+ */
 function showBanner() {
   const banner = document.getElementById('launch-banner');
   if (!banner) return;
@@ -307,6 +150,9 @@ function showBanner() {
   if (banner.__setEyesVisible) banner.__setEyesVisible(true);
 }
 
+/**
+ * Exits fullscreen mode across standard and legacy webkit prefixes.
+ */
 function exitFullscreen() {
   if (document.fullscreenElement) {
     if (document.exitFullscreen) document.exitFullscreen().catch(function () {});
@@ -315,6 +161,11 @@ function exitFullscreen() {
   }
 }
 
+/**
+ * Builds the VS Code-style editor chrome (titlebar, sidebar, tabs, statusbar) in place.
+ *
+ * @returns {Object} References to the editor's interactive regions.
+ */
 function setupEditorWindow() {
   const container = document.getElementById('pro-container');
   container.classList.add('editor-window');
@@ -323,6 +174,13 @@ function setupEditorWindow() {
   const titlebar = document.createElement('div');
   titlebar.className = 'editor-titlebar';
 
+  /**
+   * Creates a traffic-light dot that doubles as a back control.
+   *
+   * @param {string} colorClass Dot color class.
+   * @param {string} label Accessible label and tooltip.
+   * @returns {HTMLButtonElement} Dot button element.
+   */
   function makeBackDot(colorClass, label) {
     const dot = document.createElement('button');
     dot.type = 'button';
@@ -426,7 +284,10 @@ function setupEditorWindow() {
   return editorWindow;
 }
 
-var SHORT_NAMES = {
+/**
+ * Maps long section/role labels to short folder names.
+ */
+const SHORT_NAMES = {
   'Software Engineer 2 - DI App Factory': 'swe-2',
   'Software Engineer 1 - DI App Factory': 'swe-1',
   'Associate Software Developer - DI App Factory': 'asoc-dev-sc',
@@ -439,8 +300,17 @@ var SHORT_NAMES = {
   'Infrastructure': 'infra'
 };
 
-var ICON_SRC = '../../Images/information-svgrepo-com.svg';
+/**
+ * Icon shown for directory tree files.
+ */
+const ICON_SRC = '../../Images/information-svgrepo-com.svg';
 
+/**
+ * Shortens an arbitrary label into a filename-safe slug.
+ *
+ * @param {string} label Label to shorten.
+ * @returns {string} Slugged name, or the mapped short name when one exists.
+ */
 function shortName(label) {
   const clean = String(label || '').replace(/:$/, '');
   if (SHORT_NAMES[clean] !== undefined) return SHORT_NAMES[clean];
@@ -450,6 +320,9 @@ function shortName(label) {
   return parts.slice(0, 2).join('-');
 }
 
+/**
+ * Deactivates every folder header in the directory tree.
+ */
 function setActiveFolderHeader() {
   if (!editorWindow || !editorWindow.folders) return;
   editorWindow.folders.forEach(folder => {
@@ -457,6 +330,11 @@ function setActiveFolderHeader() {
   });
 }
 
+/**
+ * Marks a single directory tree item as selected and highlights its parent folder.
+ *
+ * @param {HTMLElement} [item] Tree item to mark active, or null to clear all.
+ */
 function setActiveTreeItem(item) {
   if (!editorWindow) return;
   editorWindow.entries.forEach(entry => {
@@ -470,6 +348,12 @@ function setActiveTreeItem(item) {
   }
 }
 
+/**
+ * Shows one professional section and hides the others.
+ *
+ * @param {HTMLElement} sectionEl Section to reveal.
+ * @param {HTMLElement} [item] Tree item to sync the selection to.
+ */
 function activateSection(sectionEl, item) {
   if (!editorWindow) return;
   if (editorWindow.sidebar) editorWindow.sidebar.classList.add('open');
@@ -481,6 +365,14 @@ function activateSection(sectionEl, item) {
   refreshModebarVisibility();
 }
 
+/**
+ * Adds a file entry to the directory tree that activates a section on click.
+ *
+ * @param {string} title Display name for the entry.
+ * @param {HTMLElement} sectionEl Section the entry opens.
+ * @param {HTMLElement} [item] Existing tree item to reuse.
+ * @returns {HTMLElement} The tree item element.
+ */
 function registerDirectoryEntry(title, sectionEl, item) {
   if (!editorWindow) return;
   item = item || document.createElement('div');
@@ -505,6 +397,13 @@ function registerDirectoryEntry(title, sectionEl, item) {
   return item;
 }
 
+/**
+ * Groups directory entries under a collapsible folder in the tree.
+ *
+ * @param {string} name Folder label.
+ * @param {HTMLElement} sectionEl Section the folder belongs to.
+ * @param {Object[]} tabRefs Tab references to list inside the folder.
+ */
 function registerSectionFolder(name, sectionEl, tabRefs) {
   if (!editorWindow) return;
 
@@ -549,6 +448,12 @@ function registerSectionFolder(name, sectionEl, tabRefs) {
     if (ref.view) ref.view.__treeItem = item;
   });
 
+  /**
+   * Opens or closes the folder, optionally forcing a state.
+   *
+   * @param {boolean} [force] Desired open state when provided.
+   * @returns {boolean} Whether the folder is now open.
+   */
   function toggle(force) {
     const open = typeof force === 'boolean' ? force : !folder.classList.contains('open');
     folder.classList.toggle('open', open);
@@ -566,6 +471,11 @@ function registerSectionFolder(name, sectionEl, tabRefs) {
   editorWindow.tree.appendChild(folder);
   sectionEl.style.display = 'none';
 
+  /**
+   * Sets whether the folder appears active and opens it when activated.
+   *
+   * @param {boolean} active Whether the folder should be marked active.
+   */
   folder.__setActive = function (active) {
     header.classList.toggle('active', active);
     if (active) toggle(true);
@@ -575,6 +485,11 @@ function registerSectionFolder(name, sectionEl, tabRefs) {
   editorWindow.folders.push(folder);
 }
 
+/**
+ * Renders the full professional page from parsed CV data.
+ *
+ * @param {Object} data Structured CV from parseCV().
+ */
 function renderProfessional(data) {
   const container = document.getElementById('pro-container');
   container.innerHTML = '';
@@ -596,14 +511,18 @@ function renderProfessional(data) {
   editorWindow.main.appendChild(skillsSection);
   registerSectionFolder('Skills', skillsSection, skills.tabRefs);
 
-  activateSection(expSection);
-  if (exp.tabRefs[0] && exp.tabRefs[0].item) {
-    activateSection(expSection, exp.tabRefs[0].item);
-  }
+  activateSection(expSection, exp.tabRefs[0] && exp.tabRefs[0].item);
 
   setupModebarPlacement();
 }
 
+/**
+ * Builds a full-width professional section wrapper.
+ *
+ * @param {string} title Section title (used for the element id).
+ * @param {Node} contentEl Content node to place inside the section.
+ * @returns {HTMLDivElement} Section element ready to append.
+ */
 function renderSection(title, contentEl) {
   const section = document.createElement('div');
   section.className = 'pro-section';
@@ -621,6 +540,12 @@ function renderSection(title, contentEl) {
   return section;
 }
 
+/**
+ * Builds the experience panel with a tab bar, source/preview views, and preview toggle.
+ *
+ * @param {Object[]} jobs Parsed job entries.
+ * @returns {Object} Panel wrapper, editor, and per-job tab refs.
+ */
 function renderExperience(jobs) {
   const wrapper = document.createElement('div');
   wrapper.className = 'editor-panel experience-panel';
@@ -686,6 +611,11 @@ function renderExperience(jobs) {
       wrap.className = 'editor-bullets';
       let currentUl = null;
 
+      /**
+       * Returns the active bullet list, creating one when needed.
+       *
+       * @returns {HTMLUListElement} The current list element.
+       */
       function ensureUl() {
         if (!currentUl) {
           currentUl = document.createElement('ul');
@@ -708,9 +638,9 @@ function renderExperience(jobs) {
         ensureUl().appendChild(li);
         if (bullet.sub && bullet.sub.length) {
           const subUl = document.createElement('ul');
-          bullet.sub.forEach(s => {
+          bullet.sub.forEach(sub => {
             const sl = document.createElement('li');
-            sl.innerHTML = mdInline(s);
+            sl.innerHTML = mdInline(sub);
             subUl.appendChild(sl);
           });
           li.appendChild(subUl);
@@ -737,7 +667,7 @@ function renderExperience(jobs) {
           lines.push('#'.repeat(bullet.level || 4) + ' ' + bullet.text);
         } else {
           lines.push('- ' + bullet.text);
-          (bullet.sub || []).forEach(s => lines.push('  - ' + s));
+          (bullet.sub || []).forEach(sub => lines.push('  - ' + sub));
         }
       });
       lines.push('');
@@ -763,6 +693,12 @@ function renderExperience(jobs) {
   return { wrapper: wrapper, editor: editor, tabRefs: tabRefs };
 }
 
+/**
+ * Builds the projects panel with a tab bar, source/preview views, and preview toggle.
+ *
+ * @param {Object[]} projects Parsed project entries.
+ * @returns {Object} Panel wrapper, editor, and per-project tab refs.
+ */
 function renderProjects(projects) {
   const wrapper = document.createElement('div');
   wrapper.className = 'editor-panel';
@@ -865,6 +801,12 @@ function renderProjects(projects) {
   return { wrapper: wrapper, editor: editor, tabRefs: tabRefs };
 }
 
+/**
+ * Builds the skills panel with a tab, source/preview views, and preview toggle.
+ *
+ * @param {Object[]} categories Parsed skill categories.
+ * @returns {Object} Panel wrapper, editor, and tab refs.
+ */
 function renderSkills(categories) {
   const wrapper = document.createElement('div');
   wrapper.className = 'editor-panel';
@@ -951,6 +893,12 @@ function renderSkills(categories) {
   return { wrapper: wrapper, editor: editor, tabRefs: tabRefs };
 }
 
+/**
+ * Creates the tabsbar / tabs / modebar / views skeleton for an editor panel.
+ *
+ * @param {HTMLElement} grid Element to attach the panel chrome to.
+ * @returns {Object} References to the created regions.
+ */
 function createEditorPanel(grid) {
   const tabsbar = document.createElement('div');
   tabsbar.className = 'editor-tabsbar';
@@ -975,6 +923,12 @@ function createEditorPanel(grid) {
   return { tabs: tabs, views: views, modebar: modebar, activeTab: null };
 }
 
+/**
+ * Adds a Preview | Source toggle to an editor panel's modebar.
+ *
+ * @param {HTMLElement} panel The editor panel to style on toggle.
+ * @param {HTMLElement} modebar The modebar to attach the buttons to.
+ */
 function addPreviewToggle(panel, modebar) {
   const previewBtn = document.createElement('button');
   previewBtn.type = 'button';
@@ -988,6 +942,11 @@ function addPreviewToggle(panel, modebar) {
   sourceBtn.textContent = 'Source';
   sourceBtn.setAttribute('aria-pressed', 'false');
 
+  /**
+   * Switches the panel between preview and source rendering.
+   *
+   * @param {boolean} preview Whether to show preview mode.
+   */
   function setMode(preview) {
     panel.classList.toggle('is-preview', preview);
     previewBtn.classList.toggle('active', preview);
@@ -1004,6 +963,13 @@ function addPreviewToggle(panel, modebar) {
   setMode(true);
 }
 
+/**
+ * Selects a tab within its editor panel and syncs the directory tree.
+ *
+ * @param {Object} editor Editor panel references.
+ * @param {HTMLButtonElement} tab Tab to activate.
+ * @param {HTMLElement} view View to show for the tab.
+ */
 function selectEditorFile(editor, tab, view) {
   if (editor.activeTab === tab) return;
   const previousTab = editor.activeTab;
@@ -1016,14 +982,17 @@ function selectEditorFile(editor, tab, view) {
   setActiveTreeItem(view && view.__treeItem);
 }
 
+/**
+ * Wraps the 'j' characters in the banner heading and animates them as eyes that track the cursor.
+ */
 (function initBannerEyes() {
-  var banner = document.querySelector('.launch-banner');
-  var h1 = banner && banner.querySelector('h1');
+  const banner = document.querySelector('.launch-banner');
+  const h1 = banner && banner.querySelector('h1');
   if (!h1) return;
 
-  var text = h1.textContent;
-  var wrapped = '';
-  for (var i = 0; i < text.length; i++) {
+  const text = h1.textContent;
+  let wrapped = '';
+  for (let i = 0; i < text.length; i++) {
     if (text[i] === 'j') {
       wrapped += '<span class="j-char">' + text[i] + '</span>';
     } else {
@@ -1032,10 +1001,10 @@ function selectEditorFile(editor, tab, view) {
   }
   h1.innerHTML = wrapped;
 
-  var chars = h1.querySelectorAll('.j-char');
-  var eyes = [];
+  const chars = h1.querySelectorAll('.j-char');
+  const eyes = [];
 
-  var style = document.createElement('style');
+  const style = document.createElement('style');
   style.textContent =
     '@keyframes jLidBlink {' +
     '0%,88%,100%{transform:translateX(-50%) scaleY(0)}' +
@@ -1045,21 +1014,21 @@ function selectEditorFile(editor, tab, view) {
   document.head.appendChild(style);
 
   chars.forEach(function (ch) {
-    var sclera = document.createElement('span');
+    const sclera = document.createElement('span');
     sclera.style.cssText =
-      'position:absolute;background:#fff;border-radius:50%;pointer-events:none;z-index:9;' +
+      'position:absolute;background:var(--accentLight);border-radius:50%;pointer-events:none;z-index:9;' +
       'transform:translate(-50%,-50%);';
     h1.appendChild(sclera);
 
-    var pupil = document.createElement('span');
+    const pupil = document.createElement('span');
     pupil.style.cssText =
-      'position:absolute;background:#000;border-radius:50%;pointer-events:none;z-index:10;' +
+      'position:absolute;background:var(--borderColor);border-radius:50%;pointer-events:none;z-index:10;' +
       'transform:translate(-50%,-50%);';
     h1.appendChild(pupil);
 
-    var lid = document.createElement('span');
+    const lid = document.createElement('span');
     lid.style.cssText =
-      'position:absolute;background:#1e1e1e;border-radius:50%;pointer-events:none;z-index:11;' +
+      'position:absolute;background:var(--editorBg);border-radius:50%;pointer-events:none;z-index:11;' +
       'transform:translateX(-50%) scaleY(0);' +
       'transform-origin:top center;' +
       'animation:jLidBlink ' + (5000 / 1000) + 's infinite;';
@@ -1067,13 +1036,16 @@ function selectEditorFile(editor, tab, view) {
     eyes.push({ sclera: sclera, pupil: pupil, lid: lid, chEl: ch });
   });
 
+  /**
+   * Positions the eye elements over their host characters.
+   */
   function positionEyes() {
-    var h1Rect = h1.getBoundingClientRect();
-    var fs = parseFloat(getComputedStyle(h1).fontSize);
-    var scleraSize = Math.round(fs * 0.16);
-    var pupilW = Math.round(scleraSize * 0.6);
-    var pupilH = Math.round(scleraSize * 0.6);
-    var maxDisp = (scleraSize - pupilW) / 2 - 1;
+    const h1Rect = h1.getBoundingClientRect();
+    const fs = parseFloat(getComputedStyle(h1).fontSize);
+    const scleraSize = Math.round(fs * 0.16);
+    const pupilW = Math.round(scleraSize * 0.6);
+    const pupilH = Math.round(scleraSize * 0.6);
+    const maxDisp = (scleraSize - pupilW) / 2 - 1;
 
     eyes.forEach(function (eye) {
       eye.sclera.style.width = scleraSize + 'px';
@@ -1084,9 +1056,9 @@ function selectEditorFile(editor, tab, view) {
       eye.lid.style.height = scleraSize + 'px';
       eye.maxDisp = maxDisp;
 
-      var r = eye.chEl.getBoundingClientRect();
-      var dotX = r.left + r.width / 2 - h1Rect.left;
-      var dotY = r.top + r.height * 0.22 - h1Rect.top;
+      const r = eye.chEl.getBoundingClientRect();
+      const dotX = r.left + r.width / 2 - h1Rect.left;
+      const dotY = r.top + r.height * 0.22 - h1Rect.top;
       eye.sclera.style.left = dotX + 'px';
       eye.sclera.style.top = dotY + 'px';
       eye.pupil.style.left = dotX + 'px';
@@ -1099,19 +1071,19 @@ function selectEditorFile(editor, tab, view) {
   positionEyes();
   window.addEventListener('resize', positionEyes);
 
-  var rafId = null;
+  let rafId = null;
 
   banner.addEventListener('mousemove', function (e) {
     if (rafId) return;
     rafId = requestAnimationFrame(function () {
       rafId = null;
       eyes.forEach(function (eye) {
-        var r = eye.chEl.getBoundingClientRect();
-        var cx = r.left + r.width / 2;
-        var cy = r.top + r.height * 0.22;
-        var dx = e.clientX - cx;
-        var dy = e.clientY - cy;
-        var dist = Math.sqrt(dx * dx + dy * dy);
+        const r = eye.chEl.getBoundingClientRect();
+        const cx = r.left + r.width / 2;
+        const cy = r.top + r.height * 0.22;
+        const dx = e.clientX - cx;
+        const dy = e.clientY - cy;
+        const dist = Math.sqrt(dx * dx + dy * dy);
         if (dist > eye.maxDisp) {
           dx = dx / dist * eye.maxDisp;
           dy = dy / dist * eye.maxDisp;
@@ -1121,6 +1093,11 @@ function selectEditorFile(editor, tab, view) {
     });
   });
 
+  /**
+   * Shows or hides the banner's eye elements.
+   *
+   * @param {boolean} visible Whether the eyes should be displayed.
+   */
   banner.__setEyesVisible = function (visible) {
     eyes.forEach(function (eye) {
       eye.sclera.style.display = visible ? '' : 'none';
@@ -1129,13 +1106,39 @@ function selectEditorFile(editor, tab, view) {
     });
   };
 
-  var launchBtn = document.getElementById('launch-btn');
+  const launchBtn = document.getElementById('launch-btn');
   if (launchBtn) {
     launchBtn.addEventListener('click', function () {
       banner.__setEyesVisible(false);
     });
   }
 })();
+
+/**
+ * Tracks the editor window and current mobile media query state.
+ */
+let editorWindow = null;
+let MOBILE_MQ = null;
+
+/**
+ * Loads and renders the CV into the professional editor layout.
+ */
+function loadCV() {
+  showLoading();
+  fetch('../../src/cv.md')
+    .then(res => {
+      if (!res.ok) throw new Error('Failed to fetch CV');
+      return res.text();
+    })
+    .then(text => {
+      const data = parseCV(text);
+      renderProfessional(data);
+    })
+    .catch(e => {
+      console.error('Error loading CV:', e);
+      showError('Failed to load CV data.');
+    });
+}
 
 MOBILE_MQ = window.matchMedia('(max-width: 720px)');
 if (MOBILE_MQ.addEventListener) {
@@ -1150,6 +1153,9 @@ if (MOBILE_MQ.addEventListener) {
 
 loadCV();
 
+/**
+ * Profile headlines shown in the launching banners.
+ */
 const PROFILES = [
   'Full Stack Developer',
   'AI Developer',
@@ -1158,6 +1164,9 @@ const PROFILES = [
   'IAM/PAM Analyst'
 ];
 
+/**
+ * Tooltip copy shown when hovering each profile headline.
+ */
 const PROFILE_INFO = {
   'Full Stack Developer': 'I\u2019ve spent 4+ years building enterprise-scale applications end-to-end \u2014 Next.js, ExpressJS, and SpringBoot backed by MongoDB and Redis, from API-heavy features to data analytics platforms like DDPX.',
   'AI Developer': 'I\u2019ve built AI agents and workflows in production \u2014 autonomous GitHub agentic workflows that review PRs and update docs, LangChain high/low-code agents, and an NLTK/Spacy agent that identifies owners of IAM principals.',
@@ -1166,17 +1175,23 @@ const PROFILE_INFO = {
   'IAM/PAM Analyst': 'I\u2019ve worked hands-on across identity and access management \u2014 designing RBAC in Java, setting up SAML SSO with Okta and AWS Cognito, mapping SailPoint/Okta/PingFederate data, and building analytics for orphan groups and privileged entitlements with 95% ownership accuracy.'
 };
 
-const profilesEl = document.getElementById('profiles-strip');
-if (profilesEl) {
+/**
+ * Builds the scrolling profile strip with hover tooltips.
+ */
+function buildProfilesStrip() {
   const strip = document.createElement('div');
   strip.className = 'profiles-strip';
-  profilesEl.appendChild(strip);
 
   const tooltip = document.createElement('div');
   tooltip.className = 'profile-tooltip';
   tooltip.setAttribute('role', 'tooltip');
   document.body.appendChild(tooltip);
 
+  /**
+   * Positions the tooltip near an item, staying inside the viewport.
+   *
+   * @param {HTMLElement} item The hovered profile item.
+   */
   function positionTooltip(item) {
     const rect = item.getBoundingClientRect();
     const tipRect = tooltip.getBoundingClientRect();
@@ -1191,6 +1206,11 @@ if (profilesEl) {
     tooltip.style.opacity = '1';
   }
 
+  /**
+   * Builds a single marquee group of profile items.
+   *
+   * @returns {HTMLDivElement} The completed group element.
+   */
   function buildProfile() {
     const group = document.createElement('div');
     group.className = 'profiles-group';
@@ -1204,6 +1224,9 @@ if (profilesEl) {
       item.appendChild(sep);
       group.appendChild(item);
 
+      /**
+       * Shows the tooltip for the current profile item.
+       */
       function showTooltip() {
         tooltip.textContent = PROFILE_INFO[profile] || profile;
         tooltip.style.display = 'block';
@@ -1214,6 +1237,9 @@ if (profilesEl) {
         });
       }
 
+      /**
+       * Hides the tooltip.
+       */
       function hideTooltip() {
         tooltip.style.display = 'none';
       }
@@ -1239,15 +1265,26 @@ if (profilesEl) {
 
   strip.appendChild(buildProfile());
   strip.appendChild(buildProfile());
+  return strip;
 }
 
-const launchBtn = document.getElementById('launch-btn');
-if (launchBtn) {
-  launchBtn.addEventListener('click', function () {
-    const banner = document.getElementById('launch-banner');
-    if (banner) {
-      banner.classList.add('launched');
-      launchBtn.blur();
-    }
-  });
-}
+/**
+ * Injects the profile strips and launch button behavior once, at load time.
+ */
+(function initLaunchBanner() {
+  const profilesEl = document.getElementById('profiles-strip');
+  if (profilesEl) {
+    profilesEl.appendChild(buildProfilesStrip());
+  }
+
+  const launchBtn = document.getElementById('launch-btn');
+  if (launchBtn) {
+    launchBtn.addEventListener('click', function () {
+      const banner = document.getElementById('launch-banner');
+      if (banner) {
+        banner.classList.add('launched');
+        launchBtn.blur();
+      }
+    });
+  }
+})();

--- a/scripts/resume.js
+++ b/scripts/resume.js
@@ -1,18 +1,6 @@
-function toggleSection(header) {
-  const content = header.nextElementSibling;
-  const icon = header.querySelector('.toggle-icon');
-
-  if (content.style.display === 'none') {
-    content.style.display = 'block';
-    icon.textContent = '-';
-  } else {
-    content.style.display = 'none';
-    icon.textContent = '+';
-  }
-
-  header.classList.toggle('active');
-}
-
+/**
+ * Loads `src/cv.md`, parses it, and renders the resume into the page container.
+ */
 async function loadCV() {
   const resumeContainer = document.getElementById('resume-container');
   try {
@@ -26,134 +14,11 @@ async function loadCV() {
   }
 }
 
-function parseCV(text) {
-  const lines = text.split('\n');
-  const data = { contact: {}, summary: '', experience: [], projects: [], education: [], skills: [] };
-  const fields = { Location: 'location', Email: 'email', LinkedIn: 'linkedin', Portfolio: 'portfolio', GitHub: 'github' };
-
-  function nextNonBlank(start) {
-    let j = start;
-    while (j < lines.length && lines[j].trim() === '') j++;
-    return j;
-  }
-
-  function sectionLines(start) {
-    const result = [];
-    let j = start;
-    while (j < lines.length && !lines[j].startsWith('## ')) {
-      result.push(lines[j]);
-      j++;
-    }
-    return result;
-  }
-
-  for (let i = 1; i < lines.length && !lines[i].startsWith('## '); i++) {
-    const line = lines[i].trim();
-    for (const [key, field] of Object.entries(fields)) {
-      if (line.startsWith('**' + key + ':**')) {
-        data.contact[field] = line.split('**' + key + ':**')[1].trim();
-      }
-    }
-  }
-
-  let i = 0;
-  while (i < lines.length && !lines[i].startsWith('## ')) i++;
-
-  while (i < lines.length) {
-    const section = lines[i].replace(/^## /, '').trim();
-
-    if (section === 'Professional Summary') {
-      i = nextNonBlank(i + 1);
-      const end = sectionLines(i);
-      data.summary = end.filter(l => l.trim()).join(' ');
-      i += end.length;
-      continue;
-    }
-
-    if (section === 'Work Experience') {
-      const block = sectionLines(i + 1);
-      let job = null;
-      for (const line of block) {
-        if (line.startsWith('### ')) {
-          if (job) data.experience.push(job);
-          job = { company: line.replace(/^### /, '').trim(), role: '', date: '', bullets: [] };
-        } else if (job) {
-          const t = line.trim();
-          if (t === '') continue;
-          if (t.startsWith('**') && t.endsWith('**') && !job.role) {
-            job.role = t.slice(2, -2);
-          } else if (/^#{3,6}\s/.test(t)) {
-            job.bullets.push({ kind: 'heading', text: t.replace(/^#+\s*/, '') });
-          } else if (/^[-+*]\s/.test(t) && line !== t) {
-            const last = job.bullets[job.bullets.length - 1];
-            if (last && last.kind === 'bullet') {
-              last.sub.push(t.replace(/^[-+*]\s*/, ''));
-            }
-          } else if (t.startsWith('- ')) {
-            job.bullets.push({ kind: 'bullet', text: t.slice(2), sub: [] });
-          } else if (t && !job.date) {
-            job.date = t;
-          }
-        }
-      }
-      if (job) data.experience.push(job);
-      i += block.length;
-      continue;
-    }
-
-    if (section === 'Projects') {
-      const block = sectionLines(i + 1);
-      for (const line of block) {
-        const t = line.trim();
-        if (!t.startsWith('- ')) continue;
-        const content = t.slice(2);
-        const name = content.split('**')[1] || '';
-        const afterName = content.split(')')[0] || '';
-        const tag = afterName.split('(')[1] || '';
-        const desc = content.split('--')[1] || '';
-        data.projects.push({ name: name.trim(), tag: tag.trim(), desc: desc.trim() });
-      }
-      i += block.length;
-      continue;
-    }
-
-    if (section === 'Education') {
-      const block = sectionLines(i + 1);
-      for (const line of block) {
-        const t = line.trim();
-        if (!t.startsWith('- ')) continue;
-        const content = t.slice(2);
-        const degree = content.split(',')[0].trim();
-        const rest = content.split(',')[1] || '';
-        const school = rest.split('(')[0].trim();
-        const cgpa = rest.includes('(') ? rest.split('(')[1].split(')')[0].trim() : '';
-        const dates = rest.includes(')') ? rest.split(')')[1].trim() : '';
-        data.education.push({ degree, school, cgpa, dates });
-      }
-      i += block.length;
-      continue;
-    }
-
-    if (section === 'Skills') {
-      const block = sectionLines(i + 1);
-      for (const line of block) {
-        const t = line.trim();
-        if (!t.startsWith('- ')) continue;
-        const content = t.slice(2);
-        const category = content.split('**')[1] || '';
-        const items = (content.split(':**')[1] || '').split(',').map(s => s.trim());
-        data.skills.push({ category, items });
-      }
-      i += block.length;
-      continue;
-    }
-
-    i++;
-  }
-
-  return data;
-}
-
+/**
+ * Renders the parsed CV into the resume container.
+ *
+ * @param {Object} data Structured CV from parseCV().
+ */
 function renderResume(data) {
   const container = document.getElementById('resume-container');
   container.innerHTML = '';
@@ -165,6 +30,12 @@ function renderResume(data) {
   container.appendChild(renderSection('Skills', renderSkills(data.skills), false));
 }
 
+/**
+ * Builds the resume header block with the parsed contact links.
+ *
+ * @param {Object} contact Contact fields parsed from the CV.
+ * @returns {HTMLDivElement} Header element ready to append.
+ */
 function renderHeader(contact) {
   const header = document.createElement('div');
   header.id = 'resume-header';
@@ -184,6 +55,14 @@ function renderHeader(contact) {
   return header;
 }
 
+/**
+ * Builds a collapsible resume section with heading and content.
+ *
+ * @param {string} title Section heading text.
+ * @param {Node} contentEl Content node to place inside the section.
+ * @param {boolean} active Whether the section starts expanded.
+ * @returns {HTMLDivElement} Section element ready to append.
+ */
 function renderSection(title, contentEl, active) {
   const section = document.createElement('div');
   section.className = 'resume-section';
@@ -193,7 +72,7 @@ function renderSection(title, contentEl, active) {
 
   const h2 = document.createElement('h2');
   h2.className = 'section-heading' + (active ? ' active' : '');
-  h2.onclick = function() { toggleSection(this); };
+  h2.onclick = function () { toggleSection(this); };
 
   const titleText = document.createElement('span');
   titleText.className = 'title-text';
@@ -219,12 +98,24 @@ function renderSection(title, contentEl, active) {
   return section;
 }
 
+/**
+ * Builds the professional summary paragraph.
+ *
+ * @param {string} text Summary sentence(s) from the CV.
+ * @returns {HTMLParagraphElement} Paragraph element ready to append.
+ */
 function renderSummary(text) {
   const p = document.createElement('p');
   p.textContent = text || '';
   return p;
 }
 
+/**
+ * Builds the work experience entries from parsed jobs.
+ *
+ * @param {Object[]} jobs Parsed job entries.
+ * @returns {DocumentFragment} Fragment ready to append.
+ */
 function renderExperience(jobs) {
   const wrapper = document.createDocumentFragment();
   jobs.forEach(job => {
@@ -258,9 +149,9 @@ function renderExperience(jobs) {
         li.innerHTML = mdInline(bullet.text);
         if (bullet.sub && bullet.sub.length) {
           const subUl = document.createElement('ul');
-          bullet.sub.forEach(s => {
+          bullet.sub.forEach(sub => {
             const sl = document.createElement('li');
-            sl.innerHTML = mdInline(s);
+            sl.innerHTML = mdInline(sub);
             subUl.appendChild(sl);
           });
           li.appendChild(subUl);
@@ -275,6 +166,12 @@ function renderExperience(jobs) {
   return wrapper;
 }
 
+/**
+ * Builds the projects entries from parsed projects.
+ *
+ * @param {Object[]} projects Parsed project entries.
+ * @returns {DocumentFragment} Fragment ready to append.
+ */
 function renderProjects(projects) {
   const wrapper = document.createDocumentFragment();
   projects.forEach(proj => {
@@ -302,6 +199,12 @@ function renderProjects(projects) {
   return wrapper;
 }
 
+/**
+ * Builds the education entries from parsed qualifications.
+ *
+ * @param {Object[]} items Parsed education entries.
+ * @returns {DocumentFragment} Fragment ready to append.
+ */
 function renderEducation(items) {
   const wrapper = document.createDocumentFragment();
   items.forEach(edu => {
@@ -328,6 +231,12 @@ function renderEducation(items) {
   return wrapper;
 }
 
+/**
+ * Builds the skills grid grouped by category.
+ *
+ * @param {Object[]} categories Parsed skill categories.
+ * @returns {HTMLDivElement} Skills grid element ready to append.
+ */
 function renderSkills(categories) {
   const div = document.createElement('div');
   div.className = 'skills-grid';
@@ -357,31 +266,6 @@ function renderSkills(categories) {
   });
 
   return div;
-}
-
-function escapeHtml(text) {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}
-
-function mdInline(text) {
-  let html = escapeHtml(String(text || ''));
-  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (match, label, url) {
-    const trimmed = url.trim();
-    const scheme = trimmed.match(/^([a-z][a-z0-9+.-]*):/i);
-    if (scheme && ['http', 'https', 'mailto', '#'].indexOf(scheme[1].toLowerCase()) === -1) {
-      return match;
-    }
-    return '<a href="' + escapeHtml(trimmed) + '" target="_blank" rel="noopener">' + label + '</a>';
-  });
-  html = html.replace(/\*\*\*([^*]+)\*\*\*/g, '<strong><em>$1</em></strong>');
-  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-  html = html.replace(/(^|[^*])\*([^*]+)\*/g, function (match, pre, italic) {
-    return pre + '<em>' + italic + '</em>';
-  });
-  return html;
 }
 
 initMenuToggle('#resume-container');

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -1,23 +1,308 @@
+/**
+ * Wires up the mobile menu toggle between a hidden header and the compact footer view.
+ *
+ * @param {string} contentSelector Selector for the page's main content block.
+ * @param {string} [restoreDisplay] Display value to restore on the content block.
+ */
 function initMenuToggle(contentSelector, restoreDisplay) {
-  restoreDisplay = restoreDisplay || 'block';
-  var footer = document.querySelector('footer');
-  var menuIcon = document.getElementById('menuIcon');
-  var header = document.querySelector('header');
-  var content = document.querySelector(contentSelector);
+  const defaultDisplay = restoreDisplay || 'block';
+  const footer = document.querySelector('footer');
+  const menuIcon = document.getElementById('menuIcon');
+  const header = document.querySelector('header');
+  const content = document.querySelector(contentSelector);
 
   menuIcon.addEventListener('click', () => {
-    menuIcon.style.display = "none";
-    header.style.display = "block";
-    content.style.display = "none";
-    footer.style.height = "10vh";
-    footer.style.bottom = "1%";
+    menuIcon.style.display = 'none';
+    header.style.display = 'block';
+    content.style.display = 'none';
+    footer.style.height = '10vh';
+    footer.style.bottom = '1%';
   });
 
   footer.addEventListener('click', () => {
-    menuIcon.style.display = "block";
-    footer.style.height = "18vh";
-    footer.style.bottom = "4%";
-    header.style.display = "none";
-    content.style.display = restoreDisplay;
+    menuIcon.style.display = 'block';
+    footer.style.height = '18vh';
+    footer.style.bottom = '4%';
+    header.style.display = 'none';
+    content.style.display = defaultDisplay;
   });
+}
+
+/**
+ * Escapes HTML-significant characters in a string.
+ *
+ * @param {*} str Value to escape; null/undefined become an empty string.
+ * @returns {string} Escaped HTML-safe string.
+ */
+function escapeHtml(str) {
+  return String(str ?? '').replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  }[c]));
+}
+
+/**
+ * Converts inline markdown (code, links, bold, italics) into safe HTML.
+ *
+ * @param {string} text Markdown source to render.
+ * @returns {string} Rendered HTML.
+ */
+function mdInline(text) {
+  let html = escapeHtml(String(text || ''));
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (match, label, url) {
+    const trimmed = url.trim();
+    const scheme = trimmed.match(/^([a-z][a-z0-9+.-]*):/i);
+    if (scheme && ['http', 'https', 'mailto', '#'].indexOf(scheme[1].toLowerCase()) === -1) {
+      return match;
+    }
+    return '<a href="' + escapeHtml(trimmed) + '" target="_blank" rel="noopener">' + label + '</a>';
+  });
+  html = html.replace(/\*\*\*([^*]+)\*\*\*/g, '<strong><em>$1</em></strong>');
+  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/(^|[^*])\*([^*]+)\*/g, function (match, pre, italic) {
+    return pre + '<em>' + italic + '</em>';
+  });
+  return html;
+}
+
+/**
+ * Toggles a collapsible section open/closed and marks its header active.
+ *
+ * @param {HTMLElement} header The section heading that was clicked.
+ */
+function toggleSection(header) {
+  const content = header.nextElementSibling;
+  const icon = header.querySelector('.toggle-icon');
+
+  if (content.style.display === 'none') {
+    content.style.display = '';
+    icon.textContent = '-';
+  } else {
+    content.style.display = 'none';
+    icon.textContent = '+';
+  }
+
+  header.classList.toggle('active');
+}
+
+/**
+ * Extracts `## Key: value` front-matter from a markdown blog post.
+ *
+ * @param {string} text Raw markdown source.
+ * @returns {Object} Map of lowercase front-matter keys to trimmed values.
+ */
+function parsePostHeaders(text) {
+  const meta = {};
+  for (const line of text.split('\n')) {
+    if (line.startsWith('## Paragraphs')) break;
+    const match = line.match(/^## (\w+):\s*(.+)/);
+    if (match) {
+      meta[match[1].toLowerCase()] = match[2].trim();
+    }
+  }
+  return meta;
+}
+
+/**
+ * Extracts the list of `- ` bullet paragraphs under `## Paragraphs`.
+ *
+ * @param {string} text Raw markdown source.
+ * @returns {string[]} Paragraph bodies, trimmed of the leading bullet marker.
+ */
+function parsePostBody(text) {
+  const lines = text.split('\n');
+  const bodyStart = lines.findIndex(line => line.startsWith('## Paragraphs'));
+  if (bodyStart === -1) return [];
+  return lines.slice(bodyStart + 1)
+    .filter(line => line.startsWith('- '))
+    .map(line => line.slice(2).trim());
+}
+
+/**
+ * Month lookup used to build sortable keys from "Month YYYY" dates.
+ */
+const SORT_MONTHS = { jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6, jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12 };
+
+/**
+ * Converts a "Month YYYY" start date into a numerically sortable key (YYYYMM).
+ *
+ * @param {string} dateStr Start date string to parse.
+ * @returns {number} Sortable key, or 0 when the date cannot be parsed.
+ */
+function parseStartSortKey(dateStr) {
+  const m = String(dateStr || '').trim().match(/^([A-Za-z]+)\s+(\d{4})/);
+  if (!m) return 0;
+  const mon = SORT_MONTHS[m[1].toLowerCase().slice(0, 3)];
+  if (!mon) return 0;
+  return parseInt(m[2], 10) * 100 + mon;
+}
+
+/**
+ * Returns the index of the first non-blank line at or after `start`.
+ *
+ * @param {string[]} lines Source lines.
+ * @param {number} start Line index to begin searching from.
+ * @returns {number} Index of the next non-blank line.
+ */
+function nextNonBlank(lines, start) {
+  let j = start;
+  while (j < lines.length && lines[j].trim() === '') j++;
+  return j;
+}
+
+/**
+ * Collects lines from `start` until the next `## ` section heading.
+ *
+ * @param {string[]} lines Source lines.
+ * @param {number} start Line index to begin collecting from.
+ * @returns {string[]} Lines belonging to the current section.
+ */
+function sectionLines(lines, start) {
+  const result = [];
+  let j = start;
+  while (j < lines.length && !lines[j].startsWith('## ')) {
+    result.push(lines[j]);
+    j++;
+  }
+  return result;
+}
+
+/**
+ * Parses the canonical `src/cv.md` into a structured resume object.
+ *
+ * @param {string} text Raw CV markdown source.
+ * @returns {Object} Structured CV with contact, summary, experience, projects, education, and skills.
+ */
+function parseCV(text) {
+  const lines = text.split('\n');
+  const data = { contact: {}, summary: '', experience: [], projects: [], education: [], skills: [] };
+  const fields = { Location: 'location', Email: 'email', LinkedIn: 'linkedin', Portfolio: 'portfolio', GitHub: 'github' };
+
+  let i = 0;
+  while (i < lines.length && !lines[i].startsWith('## ')) {
+    const line = lines[i].trim();
+    for (const [key, field] of Object.entries(fields)) {
+      if (line.startsWith('**' + key + ':**')) {
+        data.contact[field] = line.split('**' + key + ':**')[1].trim();
+      }
+    }
+    i++;
+  }
+
+  while (i < lines.length) {
+    const section = lines[i].replace(/^## /, '').trim();
+
+    if (section === 'Professional Summary') {
+      i = nextNonBlank(lines, i + 1);
+      const end = sectionLines(lines, i);
+      data.summary = end.filter(line => line.trim()).join(' ');
+      i += end.length;
+      continue;
+    }
+
+    if (section === 'Work Experience') {
+      const block = sectionLines(lines, i + 1);
+      let job = null;
+      for (const line of block) {
+        if (line.startsWith('### ')) {
+          if (job) data.experience.push(job);
+          job = { company: line.replace(/^### /, '').trim(), role: '', date: '', banner: '', readMore: null, bullets: [] };
+        } else if (job) {
+          const t = line.trim();
+          if (t === '') continue;
+          if (t.startsWith('**') && t.endsWith('**') && !job.role) {
+            job.role = t.slice(2, -2);
+          } else if (/^#{3,6}\s/.test(t)) {
+            job.bullets.push({ kind: 'heading', level: t.match(/^#+/)[0].length, text: t.replace(/^#+\s*/, '') });
+          } else if (/^[-+*]\s/.test(t) && line !== t) {
+            const last = job.bullets[job.bullets.length - 1];
+            if (last && last.kind === 'bullet') {
+              last.sub.push(t.replace(/^[-+*]\s*/, ''));
+            }
+          } else if (t.startsWith('- ')) {
+            job.bullets.push({ kind: 'bullet', text: t.slice(2), sub: [] });
+          } else if (/^>\s*\[([^\]]+)\]\(([^)]+)\)/.test(t)) {
+            const m = t.match(/^>\s*\[([^\]]+)\]\(([^)]+)\)/);
+            job.readMore = { label: m[1], url: m[2] };
+          } else if (/^!\[[^\]]*\]\(([^)]+)\)/.test(t)) {
+            const m = t.match(/^!\[[^\]]*\]\(([^)]+)\)/);
+            job.banner = m[1].trim();
+          } else if (t && !job.date) {
+            job.date = t;
+            job.sortKey = parseStartSortKey(t);
+          }
+        }
+      }
+      if (job) data.experience.push(job);
+      i += block.length;
+      continue;
+    }
+
+    if (section === 'Projects') {
+      const block = sectionLines(lines, i + 1);
+      let proj = null;
+      for (const line of block) {
+        const t = line.trim();
+        if (/^>\s*\[([^\]]+)\]\(([^)]+)\)/.test(t)) {
+          const m = t.match(/^>\s*\[([^\]]+)\]\(([^)]+)\)/);
+          if (proj) proj.readMore = { label: m[1], url: m[2] };
+          continue;
+        }
+        if (/^!\[[^\]]*\]\(([^)]+)\)/.test(t)) {
+          const m = t.match(/^!\[[^\]]*\]\(([^)]+)\)/);
+          if (proj) proj.banner = m[1].trim();
+          continue;
+        }
+        if (!t.startsWith('- ')) continue;
+        const content = t.slice(2);
+        const name = content.split('**')[1] || '';
+        const afterName = content.split(')')[0] || '';
+        const tag = afterName.split('(')[1] || '';
+        const desc = content.split('--')[1] || '';
+        proj = { name: name.trim(), tag: tag.trim(), desc: desc.trim(), banner: '', readMore: null };
+        data.projects.push(proj);
+      }
+      i += block.length;
+      continue;
+    }
+
+    if (section === 'Education') {
+      const block = sectionLines(lines, i + 1);
+      for (const line of block) {
+        const t = line.trim();
+        if (!t.startsWith('- ')) continue;
+        const content = t.slice(2);
+        const degree = content.split(',')[0].trim();
+        const rest = content.split(',')[1] || '';
+        const school = rest.split('(')[0].trim();
+        const cgpa = rest.includes('(') ? rest.split('(')[1].split(')')[0].trim() : '';
+        const dates = rest.includes(')') ? rest.split(')')[1].trim() : '';
+        data.education.push({ degree, school, cgpa, dates });
+      }
+      i += block.length;
+      continue;
+    }
+
+    if (section === 'Skills') {
+      const block = sectionLines(lines, i + 1);
+      for (const line of block) {
+        const t = line.trim();
+        if (!t.startsWith('- ')) continue;
+        const content = t.slice(2);
+        const category = (content.split('**')[1] || '').replace(/:$/, '');
+        const items = (content.split(':**')[1] || '').split(',').map(s => s.trim());
+        data.skills.push({ category, items });
+      }
+      i += block.length;
+      continue;
+    }
+
+    i++;
+  }
+
+  return data;
 }

--- a/styles/Home.css
+++ b/styles/Home.css
@@ -1,25 +1,10 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins&family=Raleway:wght@800&display=swap");
 @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500&display=swap');
 
-:root {
-  font-size: 16px;
-
-  --borderColor: #000000;
-  --backgroundColor: #F9F3EF;
-  --shadowColor: #09382F;
-  --contentColor: #F6DBDB;
-  --contrastText: #09382F;
-  --linkColor: #09382F;
-  --linkHover: #000000;
-
-  --headings: 'Raleway', sans-serif;
-  --poppins: 'Poppins', sans-serif;
-}
-
 body {
   padding: 1%;
   font-size: 130%;
-  font-family: "Poppins", sans-serif;
+  font-family: var(--poppins);
   display: -ms-grid;
   display: grid;
   -ms-grid-rows: 15vh 60vh 28vh;
@@ -76,7 +61,7 @@ header nav ul li :hover {
 }
 
 header nav ul li a {
-  font-family: "Poppins", sans-serif;
+  font-family: var(--poppins);
   text-decoration: none;
   color: var(--shadowColor);
 }
@@ -213,7 +198,7 @@ footer #footer_nav li a {
 
 #brand {
   font-family: var(--headings);
-  color: black;
+  color: var(--borderColor);
 }
 
 

--- a/styles/MySpace.css
+++ b/styles/MySpace.css
@@ -512,8 +512,8 @@
 }
 
 .lc-submission-status.is-wronganswer {
-  background-color: #b3261e;
-  color: #ffffff;
+  background-color: var(--errorColor);
+  color: var(--errorTextColor);
 }
 
 .lc-submission-lang {

--- a/styles/Professional.css
+++ b/styles/Professional.css
@@ -36,6 +36,8 @@ body.pro-page {
   --green: #27c93f;
   --commentGreen: #6a9955;
   --statusBarBlue: #007acc;
+  --tooltipShadow: rgba(0, 0, 0, 0.45);
+  --tabHoverBg: rgba(255, 255, 255, 0.1);
 
   display: block;
   min-height: 100vh;
@@ -315,7 +317,7 @@ body.pro-page {
   font-size: 0.85rem;
   line-height: 1.5;
   color: var(--editorText);
-  box-shadow: 0 0.4rem 1rem rgba(0, 0, 0, 0.45);
+  box-shadow: 0 0.4rem 1rem var(--tooltipShadow);
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.15s ease;
@@ -889,7 +891,7 @@ body.pro-page .page-container {
 
 .editor-tab:hover .editor-tab-close {
   color: var(--accentLight);
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--tabHoverBg);
 }
 
 .editor-tab:hover {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,3 +1,20 @@
+:root {
+  font-size: 16px;
+
+  --borderColor: #000000;
+  --backgroundColor: #F9F3EF;
+  --shadowColor: #09382F;
+  --contentColor: #F6DBDB;
+  --contrastText: #09382F;
+  --linkColor: #09382F;
+  --linkHover: #000000;
+  --errorColor: #b3261e;
+  --errorTextColor: #ffffff;
+
+  --headings: 'Raleway', sans-serif;
+  --poppins: 'Poppins', sans-serif;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }


### PR DESCRIPTION
Closes #44

## What

Brings the codebase in line with AGENTS.md conventions by consolidating duplicated helpers into `shared.js`, enforcing `const`/`let` + JSDoc + single quotes, and moving theme variables into `styles/styles.css`, while further evolving the professional page into a VS Code-style editor.

## Why

Page scripts each carried their own copies of the markdown/CV parsers and escaping helpers, used `var`, hardcoded colors, and inconsistent asset load order, which made any fix risky and diverged from the project norms. The professional page also matured through a folder-tree sidebar, markdown preview/source toggle, and an animated cursor-tracking banner. This PR removes the duplication (issue #44) and delivers those page improvements.

## Changes

- **`scripts/shared.js`** — single home for `escapeHtml`, `mdInline`, `toggleSection`, `parseCV`, blog-post parsers, and sort keys
- **`scripts/resume.js`, `professional.js`, `myspace.js`, `blog.js`, `home.js`** — dropped duplicated helpers; `var` → `const`/`let`; added JSDoc; single quotes
- **`styles/styles.css`** — theme `:root` custom properties, including new error colors
- **`styles/Home.css`, `MySpace.css`, `Professional.css`** — replaced hardcoded colors/typography with custom properties
- **`index.html` and sub-pages** — corrected CSS/script load order; added `shared.js` to the Professional page
- **`scripts/professional.js`** — VS Code-style editor chrome, collapsible folder tree, Preview/Source toggle, cursor-tracking banner eyes
- **`AGENTS.md`** — new project norms document
- **`plan/` and `src/professionalResume.md`** — feature plans and a dedicated professional resume source
- **`README.md`** — updated; removed stray `.DS_Store` files

## How it works

1. `shared.js` consolidates the shared helpers; every page loads it before its own script
2. Page scripts render CV and post data through `parseCV` / `parsePostHeaders` from `shared.js`
3. `professional.js` builds the editor chrome, tree folders, and tab/source/preview views from the parsed data
4. Banner eyes track the cursor over the `h1` and blink via injected keyframes

## To verify

1. Open each page locally (index, Blog, Resume, MySpace, Professional) and confirm no console errors
2. On Professional, click tree folders/tabs and the Preview/Source toggles and confirm sections switch
3. Hover the banner `h1` and confirm the eyes track the cursor and blink