### PR TITLE
Add site-wide font theme switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,15 @@
       </li>
     </ul>
   </footer>
+<div id="font-switcher" aria-label="Font style switcher">
+    <ul id="font-switcher-menu" hidden>
+      <li><button data-font-theme="default">Default</button></li>
+      <li><button data-font-theme="sans">Modern Sans</button></li>
+      <li><button data-font-theme="ebook">eBook</button></li>
+      <li><button data-font-theme="scholarly">Scholarly</button></li>
+    </ul>
+    <button id="font-switcher-toggle" aria-label="Choose font style" aria-expanded="false" data-tooltip="Choose font style">Aa</button>
+  </div>
 </body>
 <script src="./scripts/shared.js"></script>
 <script src="./scripts/home.js"></script>

--- a/pages/Blog/Blog.html
+++ b/pages/Blog/Blog.html
@@ -84,6 +84,16 @@
     </ul>
   </footer>
 
+  <div id="font-switcher" aria-label="Font style switcher">
+    <ul id="font-switcher-menu" hidden>
+      <li><button data-font-theme="default">Default</button></li>
+      <li><button data-font-theme="sans">Modern Sans</button></li>
+      <li><button data-font-theme="ebook">eBook</button></li>
+      <li><button data-font-theme="scholarly">Scholarly</button></li>
+    </ul>
+    <button id="font-switcher-toggle" aria-label="Choose font style" aria-expanded="false" data-tooltip="Choose font style">Aa</button>
+  </div>
+
   <script src="../../scripts/shared.js"></script>
   <script src="../../scripts/blog.js"></script>
 </body>

--- a/pages/MySpace/MySpace.html
+++ b/pages/MySpace/MySpace.html
@@ -194,6 +194,16 @@
   </footer>
 
 
+  <div id="font-switcher" aria-label="Font style switcher">
+    <ul id="font-switcher-menu" hidden>
+      <li><button data-font-theme="default">Default</button></li>
+      <li><button data-font-theme="sans">Modern Sans</button></li>
+      <li><button data-font-theme="ebook">eBook</button></li>
+      <li><button data-font-theme="scholarly">Scholarly</button></li>
+    </ul>
+    <button id="font-switcher-toggle" aria-label="Choose font style" aria-expanded="false" data-tooltip="Choose font style">Aa</button>
+  </div>
+
   <script src="../../scripts/shared.js"></script>
   <script src="../../scripts/myspace.js"></script>
 </body>

--- a/pages/Professional/Professional.html
+++ b/pages/Professional/Professional.html
@@ -56,6 +56,16 @@
     </div>
   </section>
 
+  <div id="font-switcher" aria-label="Font style switcher">
+    <ul id="font-switcher-menu" hidden>
+      <li><button data-font-theme="default">Default</button></li>
+      <li><button data-font-theme="sans">Modern Sans</button></li>
+      <li><button data-font-theme="ebook">eBook</button></li>
+      <li><button data-font-theme="scholarly">Scholarly</button></li>
+    </ul>
+    <button id="font-switcher-toggle" aria-label="Choose font style" aria-expanded="false" data-tooltip="Choose font style">Aa</button>
+  </div>
+
   <script src="../../scripts/shared.js"></script>
   <script src="../../scripts/professional.js"></script>
 </body>

--- a/pages/Resume/Resume.html
+++ b/pages/Resume/Resume.html
@@ -81,6 +81,16 @@
   </footer>
 
 
+  <div id="font-switcher" aria-label="Font style switcher">
+    <ul id="font-switcher-menu" hidden>
+      <li><button data-font-theme="default">Default</button></li>
+      <li><button data-font-theme="sans">Modern Sans</button></li>
+      <li><button data-font-theme="ebook">eBook</button></li>
+      <li><button data-font-theme="scholarly">Scholarly</button></li>
+    </ul>
+    <button id="font-switcher-toggle" aria-label="Choose font style" aria-expanded="false" data-tooltip="Choose font style">Aa</button>
+  </div>
+
   <script src="../../scripts/shared.js"></script>
   <script src="../../scripts/resume.js"></script>
 </body>

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -306,3 +306,52 @@ function parseCV(text) {
 
   return data;
 }
+
+/**
+ * Font themes selectable in the switcher, keyed by the data attribute value.
+ */
+const fontThemes = ['default', 'sans', 'ebook', 'scholarly'];
+
+/**
+ * Initializes the bottom-right font switcher: restores the saved theme
+ * and wires up the toggle plus selection handlers.
+ */
+function initFontSwitcher() {
+  const toggle = document.getElementById('font-switcher-toggle');
+  const menu = document.getElementById('font-switcher-menu');
+  if (!toggle || !menu) return;
+
+  const saved = localStorage.getItem('font-theme');
+  if (saved && fontThemes.includes(saved)) {
+    document.body.dataset.fontTheme = saved;
+  }
+  updateThemeButtons();
+
+  toggle.addEventListener('click', () => {
+    const open = menu.hidden;
+    menu.hidden = !open;
+    toggle.setAttribute('aria-expanded', String(open));
+  });
+
+  menu.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-font-theme]');
+    if (!button) return;
+    document.body.dataset.fontTheme = button.dataset.fontTheme;
+    localStorage.setItem('font-theme', button.dataset.fontTheme);
+    updateThemeButtons();
+    menu.hidden = true;
+    toggle.setAttribute('aria-expanded', 'false');
+  });
+}
+
+/**
+ * Highlights the active theme option in the switcher menu.
+ */
+function updateThemeButtons() {
+  const active = document.body.dataset.fontTheme || 'default';
+  document.querySelectorAll('#font-switcher-menu button[data-font-theme]').forEach(button => {
+    button.classList.toggle('active', button.dataset.fontTheme === active);
+  });
+}
+
+initFontSwitcher();

--- a/styles/Blog.css
+++ b/styles/Blog.css
@@ -1,3 +1,13 @@
+#post-title {
+  font-family: var(--theme-heading-font);
+}
+
+.card-date,
+.post-paragraph,
+#post-date {
+  font-family: var(--theme-content-font);
+}
+
 #blog-list {
   display: flex;
   flex-direction: column;
@@ -80,7 +90,6 @@
   color: var(--shadowColor);
   font-size: var(--text-sm);
   margin: 0 0 0.8rem 0;
-  font-family: var(--poppins);
   font-weight: normal;
   opacity: 0.85;
 }
@@ -122,7 +131,6 @@
 }
 
 #post-title {
-  font-family: var(--headings);
   color: var(--shadowColor);
   font-size: var(--text-3xl);
   margin: 0 0 0.5rem 0;
@@ -133,7 +141,6 @@
   color: var(--shadowColor);
   font-size: var(--text-base);
   margin: 0 0 2rem 0;
-  font-family: var(--poppins);
   font-weight: normal;
   opacity: 0.85;
 }

--- a/styles/Home.css
+++ b/styles/Home.css
@@ -4,7 +4,7 @@
 body {
   padding: 1%;
   font-size: var(--text-base);
-  font-family: var(--poppins);
+  font-family: var(--theme-content-font);
   display: -ms-grid;
   display: grid;
   -ms-grid-rows: 15vh 60vh auto;
@@ -61,7 +61,7 @@ header nav ul li :hover {
 }
 
 header nav ul li a {
-  font-family: var(--poppins);
+  font-family: var(--theme-content-font);
   text-decoration: none;
   color: var(--shadowColor);
 }
@@ -103,6 +103,7 @@ section #hero p {
 }
 
 section #hero p {
+  font-family: var(--theme-content-font);
   text-align: justify;
   font-size: var(--text-base);
 }
@@ -199,8 +200,12 @@ footer #footer_nav li a {
 }
 
 #brand {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   color: var(--borderColor);
+}
+
+footer h1 {
+  font-family: var(--theme-heading-font);
 }
 
 

--- a/styles/MySpace.css
+++ b/styles/MySpace.css
@@ -644,7 +644,7 @@
   border: 0.2rem solid var(--borderColor);
   border-radius: 0.3rem;
   padding: 0.6rem 1.2rem;
-  font-family: var(--poppins);
+  font-family: var(--theme-content-font);
   font-size: var(--text-base);
   cursor: pointer;
   transition: all 0.2s ease;
@@ -691,7 +691,7 @@
 }
 
 #book-title {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   color: var(--shadowColor);
   font-size: var(--text-3xl);
   margin: 0 0 0.5rem 0;
@@ -702,7 +702,7 @@
   color: var(--shadowColor);
   font-size: var(--text-base);
   margin: 0 0 0.4rem 0;
-  font-family: var(--poppins);
+  font-family: var(--theme-content-font);
   opacity: 0.85;
 }
 
@@ -710,7 +710,7 @@
   color: var(--borderColor);
   font-size: var(--text-sm);
   margin: 0 0 1.2rem 0;
-  font-family: var(--poppins);
+  font-family: var(--theme-content-font);
   opacity: 0.8;
 }
 

--- a/styles/Resume.css
+++ b/styles/Resume.css
@@ -6,7 +6,7 @@
 }
 
 #resume-header h1 {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   font-size: var(--text-5xl);
   color: var(--borderColor);
   margin-bottom: 1%;
@@ -98,7 +98,7 @@
 }
 
 .job h3 {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   font-size: var(--text-xl);
   color: var(--borderColor);
   margin-bottom: 0.3%;
@@ -146,7 +146,7 @@
 
 .job .resume-subheading {
   list-style: none;
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--borderColor);
@@ -179,7 +179,7 @@
 }
 
 .project h3 {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   font-size: var(--text-xl);
   color: var(--borderColor);
   margin-bottom: 0.5%;
@@ -197,7 +197,7 @@
 }
 
 .education h3 {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   font-size: var(--text-xl);
   color: var(--borderColor);
   margin-bottom: 0.3%;
@@ -214,7 +214,7 @@
 }
 
 .skill-category h3 {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   font-size: var(--text-lg);
   color: var(--borderColor);
   margin-bottom: 1.5%;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=Literata:opsz,wght@7..72,400;7..72,600&family=Libre+Baskerville:wght@400;700&display=swap');
+
 :root {
   font-size: 16px;
 
@@ -14,6 +16,9 @@
 
   --headings: 'Raleway', sans-serif;
   --poppins: 'Poppins', sans-serif;
+
+  --theme-heading-font: var(--headings);
+  --theme-content-font: var(--poppins);
 
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;
@@ -33,6 +38,21 @@
   --measure-narrow: 45ch;
   --measure-normal: 66ch;
   --measure-wide: 75ch;
+}
+
+[data-font-theme='sans'] {
+  --theme-heading-font: 'Sora', sans-serif;
+  --theme-content-font: 'Sora', sans-serif;
+}
+
+[data-font-theme='ebook'] {
+  --theme-heading-font: 'Literata', serif;
+  --theme-content-font: 'Literata', serif;
+}
+
+[data-font-theme='scholarly'] {
+  --theme-heading-font: 'Libre Baskerville', serif;
+  --theme-content-font: 'Libre Baskerville', serif;
 }
 
 @keyframes fadeIn {
@@ -77,7 +97,7 @@ body.sub-page section {
 }
 
 .section-heading {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   font-size: var(--text-2xl);
   color: var(--backgroundColor);
   padding: 1.2% 2%;
@@ -129,13 +149,14 @@ body.sub-page section {
 
 
 .card-title {
-  font-family: var(--headings);
+  font-family: var(--theme-heading-font);
   color: var(--shadowColor);
   font-size: var(--text-xl);
   margin: 0 0 0.5rem 0;
 }
 
 .card-excerpt {
+  font-family: var(--theme-content-font);
   font-size: var(--text-base);
   color: var(--borderColor);
   line-height: var(--leading-relaxed);
@@ -216,4 +237,105 @@ body.sub-page section {
     font-size: var(--text-xs);
     width: 100%;
   }
+}
+
+#font-switcher {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+#font-switcher-toggle {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 0.2rem solid var(--borderColor);
+  background-color: var(--contentColor);
+  color: var(--borderColor);
+  font-family: var(--headings);
+  font-size: var(--text-base);
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0.2rem 0.2rem var(--shadowColor);
+  transition: all 0.2s ease;
+}
+
+#font-switcher-toggle:hover {
+  transform: translateY(-0.1rem) translateX(0.1rem);
+  box-shadow: 0.3rem 0.3rem var(--shadowColor);
+}
+
+#font-switcher-toggle[data-tooltip] {
+  position: relative;
+}
+
+#font-switcher-toggle[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  right: 120%;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: var(--contentColor);
+  color: var(--borderColor);
+  font-family: var(--poppins);
+  font-size: var(--text-xs);
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.25rem;
+  border: 0.1rem solid var(--borderColor);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 200;
+}
+
+#font-switcher-toggle[data-tooltip]:hover::after {
+  opacity: 1;
+}
+
+#font-switcher-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem;
+  background-color: var(--backgroundColor);
+  border: 0.15rem solid var(--borderColor);
+  border-radius: 0.4rem;
+  box-shadow: 0.2rem 0.2rem var(--shadowColor);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 100%;
+}
+
+#font-switcher-menu[hidden] {
+  display: none;
+}
+
+#font-switcher-menu button {
+  background: none;
+  border: 0.1rem solid var(--backgroundColor);
+  padding: 0.5rem 0.75rem;
+  font-size: var(--text-sm);
+  font-family: var(--poppins);
+  color: var(--shadowColor);
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+  border-radius: 0.25rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+  width: 100%;
+}
+
+#font-switcher-menu button:hover {
+  border-color: var(--borderColor);
+}
+
+#font-switcher-menu button.active {
+  background-color: var(--shadowColor);
+  color: var(--backgroundColor);
 }


### PR DESCRIPTION
Closes #48

## What

Add a bottom-right font switcher that lets visitors choose among Default, Modern Sans, eBook, and Scholarly typography themes across the entire site.

## Why

Blog, resume, and book-reading content benefit from reader-chosen typography, but visitors previously had no way to change fonts. Theming is driven by CSS custom properties, so any element can opt in without per-page JavaScript, and the choice persists per visitor.

## Changes

- **`styles/styles.css`** — add Sora/Literata/Libre Baskerville imports, `--theme-heading-font`/`--theme-content-font` vars, `[data-font-theme]` overrides, and the switcher widget styles
- **`scripts/shared.js`** — add `initFontSwitcher()`, `updateThemeButtons()`, `fontThemes` list, and localStorage persistence
- **`index.html`, `pages/{Blog,Resume,MySpace,Professional}`** — add the switcher markup to every page
- **`styles/Home.css`** — route body, nav, brand, hero, and footer fonts through the theme vars
- **`styles/{Blog,Resume,MySpace}.css`** — swap hardcoded `--headings`/`--poppins` for the theme vars on headings, content, and book detail

## How it works

1. The switcher menu buttons set `document.body.dataset.fontTheme` and save `font-theme` to localStorage.
2. CSS `[data-font-theme='sans'|'ebook'|'scholarly']` selectors override the two theme properties; `default` falls back to the `:root` Raleway/Poppins defaults.
3. Components reference `var(--theme-heading-font)` / `var(--theme-content-font)` instead of the static font vars.
4. On load, `initFontSwitcher()` restores the saved theme and highlights the active option.

## To verify

1. Open any page and click `Aa` in the bottom-right corner.
2. Pick eBook/Scholarly and confirm headings and body text change.
3. Reload the page to confirm the choice persists.