### PR TITLE
Add study plans for algorithms and system design

### DIFF
--- a/src/StudyPlans/algorithms-and-leetcode.md
+++ b/src/StudyPlans/algorithms-and-leetcode.md
@@ -1,0 +1,141 @@
+# Study Plan: Algorithms & LeetCode: Grokking Algorithms + Blind-75
+
+## Phase 1: Algorithm Foundations
+
+### Week 1: Algorithm Basics & Sorting
+
+- [ ] Introduction to algorithms — what algorithms are, why they matter
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+  - Site: [LeetCode 75 Study Plan](https://leetcode.com/studyplan/leetcode-75/)
+- [ ] Big-O notation — time and space complexity, common complexities (O(1), O(n), O(n log n), O(n²))
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] How memory works — stack vs heap, reference vs value types
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Selection sort — how it works, O(n²) analysis
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Binary — sum of two integers (bitwise), number of 1 bits
+  - Site: [Two Sum](https://leetcode.com/problems/two-sum/)
+  - Site: [Sum of Two Integers](https://leetcode.com/problems/sum-of-two-integers/)
+  - Site: [Number of 1 Bits](https://leetcode.com/problems/number-of-1-bits/)
+  - Site: [14 Patterns to Ace Any Coding Interview](https://hackernoon.com/14-patterns-to-ace-any-coding-interview-question-c5bb3357f6ed)
+- [ ] Array basics — Two Sum (hash table approach), Contains Duplicate
+  - Site: [Best Time to Buy and Sell Stock](https://leetcode.com/problems/best-time-to-buy-and-sell-stock/)
+  - Site: [Contains Duplicate](https://leetcode.com/problems/contains-duplicate/)
+- [ ] String basics — Valid Parentheses, Valid Palindrome
+  - Site: [Valid Parentheses](https://leetcode.com/problems/valid-parentheses/)
+  - Site: [Valid Palindrome](https://leetcode.com/problems/valid-palindrome/)
+
+### Week 2: Recursion & Data Structures
+
+- [ ] Recursion — base cases, recursive vs iterative, call stack
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Linked lists — nodes, traversal, O(1) insertion/deletion
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Arrays — vs linked lists, random access, O(1) vs O(n) operations
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Product of Array Except Self (prefix/suffix product approach)
+  - Site: [Product of Array Except Self](https://leetcode.com/problems/product-of-array-except-self/)
+- [ ] Maximum Subarray (Kadane's algorithm)
+  - Site: [Maximum Subarray](https://leetcode.com/problems/maximum-subarray/)
+- [ ] Reverse a Linked List
+  - Site: [Reverse a Linked List](https://leetcode.com/problems/reverse-linked-list/)
+- [ ] Counting Bits
+  - Site: [Counting Bits](https://leetcode.com/problems/counting-bits/)
+- [ ] Longest Substring Without Repeating Characters (sliding window)
+  - Site: [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters/)
+
+## Phase 2: Core Algorithms & Data Structures
+
+### Week 3: Quicksort & Hash Tables
+
+- [ ] Quicksort — divide and conquer, partitioning, average O(n log n)
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Hash tables — hash functions, collision handling, O(1) lookups
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Using hash tables for lookups
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Preventing duplicate entries
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Using hash tables as a cache
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Search in Rotated Sorted Array (binary search variant)
+  - Site: [Search in Rotated Sorted Array](https://leetcode.com/problems/search-in-rotated-sorted-array/)
+  - Site: [Find Minimum in Rotated Sorted Array](https://leetcode.com/problems/find-minimum-in-rotated-sorted-array/)
+  - Site: [Missing Number](https://leetcode.com/problems/missing-number/)
+- [ ] Two Pointers — Container With Most Water
+  - Site: [Container With Most Water](https://leetcode.com/problems/container-with-most-water/)
+- [ ] Valid Anagram (hash frequency count)
+  - Site: [Valid Anagram](https://leetcode.com/problems/valid-anagram/)
+
+### Week 4: Graphs & BFS
+
+- [ ] Graphs — nodes, edges, adjacency list, adjacency matrix
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Breadth-first search (BFS) — queue-based traversal, shortest path on unweighted graphs
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Maximum Product Subarray
+  - Site: [Maximum Product Subarray](https://leetcode.com/problems/maximum-product-subarray/)
+- [ ] Merge Intervals (sorting + merging)
+  - Site: [Merge Intervals](https://leetcode.com/problems/merge-intervals/)
+- [ ] Merge K Sorted Lists (heap approach)
+  - Site: [Merge K Sorted Lists](https://leetcode.com/problems/merge-k-sorted-lists/)
+- [ ] Number of Islands (BFS/DFS on grid)
+  - Site: [Number of Islands](https://leetcode.com/problems/number-of-islands/)
+- [ ] Clone Graph
+  - Site: [Clone Graph](https://leetcode.com/problems/clone-graph/)
+- [ ] Group Anagrams (hash-based grouping)
+  - Site: [Group Anagrams](https://leetcode.com/problems/group-anagrams/)
+
+## Phase 3: Advanced Algorithms & Optimization
+
+### Week 5: Shortest Path & Greedy
+
+- [ ] Dijkstra's algorithm — weighted graphs, priority queue, O((V + E) log V)
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Greedy algorithms — local optimum, interval scheduling, when greedy works
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Course Schedule (topological sort / graph)
+  - Site: [Course Schedule](https://leetcode.com/problems/course-schedule/)
+- [ ] Pacific Atlantic Water Flow (multi-source BFS)
+  - Site: [Pacific Atlantic Water Flow](https://leetcode.com/problems/pacific-atlantic-water-flow/)
+- [ ] Longest Consecutive Sequence (hash set approach)
+  - Site: [Longest Consecutive Sequence](https://leetcode.com/problems/longest-consecutive-sequence/)
+- [ ] Insert Interval
+  - Site: [Insert Interval](https://leetcode.com/problems/insert-interval/)
+- [ ] Non-overlapping Intervals
+  - Site: [Non-overlapping Intervals](https://leetcode.com/problems/non-overlapping-intervals/)
+- [ ] Top K Frequent Elements (heap approach)
+  - Site: [Top K Frequent Elements](https://leetcode.com/problems/top-k-frequent-elements/)
+
+### Week 6: Dynamic Programming & KNN
+
+- [ ] Dynamic Programming — memoization, tabulation, optimal substructure
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] The knapsack problem — 0/1 vs unbounded, DP table construction
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] K-nearest neighbors (KNN) — distance metrics, feature extraction
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+- [ ] Climbing Stairs (intro to DP)
+  - Site: [Climbing Stairs](https://leetcode.com/problems/climbing-stairs/)
+- [ ] Coin Change (DP)
+  - Site: [Coin Change](https://leetcode.com/problems/coin-change/)
+- [ ] House Robber (DP)
+  - Site: [House Robber](https://leetcode.com/problems/house-robber/)
+- [ ] Longest Increasing Subsequence
+  - Site: [Longest Increasing Subsequence](https://leetcode.com/problems/longest-increasing-subsequence/)
+- [ ] Word Break Problem
+  - Site: [Word Break Problem](https://leetcode.com/problems/word-break/)
+- [ ] Jump Game
+  - Site: [Jump Game](https://leetcode.com/problems/jump-game/)
+- [ ] Matrix — Set Matrix Zeroes, Rotate Image
+  - Site: [Set Matrix Zeroes](https://leetcode.com/problems/set-matrix-zeroes/)
+  - Site: [Rotate Image](https://leetcode.com/problems/rotate-image/)
+- [ ] Where to Go Next — recommended next topics (trees, advanced DP, system design)
+  - Book: "Grokking Algorithms" by Aditya Y. Bhargava
+
+## Weekly Schedule Suggestion
+
+- 3 hours theory per week
+- 2 hours hands-on coding per week
+- 1 hour review/notes per week
+- Weekend: 1 project milestone or challenge

--- a/src/StudyPlans/code-architecture-system-design.md
+++ b/src/StudyPlans/code-architecture-system-design.md
@@ -1,0 +1,233 @@
+# Study Plan: Code Architecture & System Design
+
+## Phase 1: Foundations — Domain Modeling & Scaling Basics
+
+### Week 1: Domain Modeling & Capacity Estimation
+
+- [ ] Domain Modeling — ubiquitous language, domain events, mapping domain to code
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Bounded contexts and context mapping
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Scaling from zero to millions — the 6 dimensions of scaling
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Back-of-the-envelope estimation — request rates, storage, bandwidth calculations
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Load estimation — RPS, latency targets, throughput, capacity planning
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Workload analysis — read-heavy, write-heavy, compute-intensive
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Design a URL shortener — requirements, capacity estimation, API design
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+  - Site: [System Design Questions (Arpit B Bhayani)](https://github.com/arpitbbhayani/system-design-questions)
+- [ ] Design a key-value store — requirements, data model, scaling strategy
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+
+### Week 2: Persistent Storage — Repository & Unit of Work
+
+- [ ] Repository Pattern — abstraction over data access, separation of persistence logic
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Unit of Work Pattern — transaction management, saving invariants, identity map
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Aggregate Roots and Consistency Boundaries
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Data modeling for scale — relational vs document vs columnar stores
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Key-value stores — Redis, DynamoDB, storage engines, TTL, replication
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Relational databases for scale — partitioning, sharding, read replicas
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Storage design interview question — Google Drive file storage
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Implement a Repository pattern in Python with SQLAlchemy
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+
+### Week 3: Coupling, Abstractions & Consistent Hashing
+
+- [ ] Coupling and Abstractions — high cohesion, loose coupling, dependency inversion
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Dependency Injection and Bootstrapping — container, wiring, configuration
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Microservices — when to split, when not to, service boundaries
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Scaling basics — vertical vs horizontal, stateless services, session management
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Consistent Hashing — hash ring, virtual nodes, handling churn
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Caching fundamentals — CDN, in-memory cache, cache-aside, write-through
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Load balancing — L4 vs L7, round-robin, least connections, sticky sessions
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Design a web crawler — URL frontier, deduplication, politeness, distributed crawling
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+
+## Phase 2: Architecture at Scale — APIs, Testing & Frameworks
+
+### Week 4: Service Layers & API Design
+
+- [ ] Service Layer Pattern — orchestrating use cases, transaction coordination
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Flask API design — routing, request/response lifecycle, middleware
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] RESTful API design — resource modeling, HTTP semantics, pagination, filtering
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] gRPC and protobuf — when to use RPC vs REST, streaming, service discovery
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] API versioning and backward compatibility
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] News Feed System — fan-out on write vs fan-out on read, hybrid approaches
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Chat System — real-time messaging, WebSocket architecture, presence, offline delivery
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Build a service layer with Flask that coordinates Repository and Unit of Work
+
+### Week 5: TDD & System Design Framework
+
+- [ ] TDD in High Gear — fast, isolated unit tests, test doubles, assertions
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] TDD in Low Gear — integration tests, database fixtures, contract tests
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Testing infrastructure — mocking external services, test containers, CI pipelines
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] System Design Interview Framework — clarification, estimation, interface design, deep dive
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] System Design fundamentals — CAP theorem, consistency models, failover strategies
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Distributed caching — Redis clustering, Memcached, invalidation strategies
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Design a search autocomplete system — trie structures, prefix search, latency optimization
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Write integration tests for a Flask service with database and external API calls
+
+### Week 6: Microservices & Distributed Messaging Foundations
+
+- [ ] Events and the Message Bus — pub/sub pattern, event routing, subscriber management
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Going to Town on the Message Bus — RabbitMQ, message acknowledgment, dead letter queues
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Commands and Command Handlers — CQS, command validation, idempotent handlers
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Message queues in distributed systems — Kafka, RabbitMQ, SQS
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Design a notification system — multi-channel (email, push, SMS), delivery guarantees, queuing
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Design YouTube — video ingest, transcoding pipeline, CDN distribution, streaming
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Build a simple message bus in Python with RabbitMQ and pub/sub subscribers
+
+## Phase 3: Advanced Patterns — Events, CQRS & End-to-End System Design
+
+### Week 7: Event-Driven Architecture
+
+- [ ] Event-Driven Architecture — using events to integrate microservices, event sourcing basics
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Event Sourcing — command log, snapshots, projections, replay semantics
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Saga Pattern — choreography vs orchestration, compensating transactions
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Event streaming at scale — Kafka architecture, partitioning, consumer groups, replay
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] YouTube deep dive — content delivery network architecture, adaptive bitrate streaming
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Google Drive deep dive — file sync, conflict resolution, delta sync, storage deduplication
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Design a distributed task scheduler — job queues, retry logic, distributed locking
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+
+### Week 8: CQRS & Read/Write Separation at Scale
+
+- [ ] Command-Query Responsibility Segregation (CQRS) — separating read and write models
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Query-side patterns — denormalization, materialized views, search index sync
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Eventual consistency — caveats, anti-patterns, handling stale reads
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Database replication strategies — synchronous vs asynchronous, replication lag
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Search architecture — Elasticsearch, full-text search, faceting, ranking
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Graph databases and social feeds — relationship queries, graph traversals
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Design a social media news feed — ranking algorithms, personalization, feed generation
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+
+### Week 9: End-to-End System Design
+
+- [ ] End-to-end system design — taking a problem statement from requirements to architecture
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Requirements clarification — functional vs non-functional, constraints, edge cases
+- [ ] Capacity estimation from requirements — traffic estimation, storage sizing, bandwidth
+- [ ] High-level design — component diagram, data flow, service boundaries
+- [ ] Deep dive on data model — schema design, indexing strategy, partitioning
+- [ ] Deep dive on scalability — horizontal scaling, caching strategy, load balancing
+- [ ] Trade-off analysis — consistency vs availability, latency vs throughput, cost vs performance
+- [ ] System Design Interview Questions repo — practice questions on distributed systems, scalability
+  - Site: [System Design Questions (Arpit B Bhayani)](https://github.com/arpitbbhayani/system-design-questions)
+- [ ] Mock interview: Design a URL shortener (full lifecycle from requirements to architecture)
+- [ ] Mock interview: Design a chat system with real-time messaging and history
+- [ ] Mock interview: Design a video streaming platform like YouTube
+
+## Phase 4: Hands-On Projects
+
+### Project 1: Domain-Driven Blogging Platform
+
+- [ ] Model the blogging domain — Post, Author, Comment, Tag aggregates with domain events
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Implement Repository Pattern for Post and Comment persistence
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Implement Unit of Work for transactional CRUD operations
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Build a Flask API service layer with CRUD endpoints and pagination
+- [ ] Add caching layer for post listings (cache-aside pattern)
+- [ ] Write integration tests with real database using test containers
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Add Redis caching for hot posts and per-user feed segments
+
+### Project 2: Distributed Key-Value Store
+
+- [ ] Design and implement a distributed key-value store with replication
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Implement consistent hashing for node assignment and rebalancing
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Add support for TTL (time-to-live) on keys
+- [ ] Implement leader-based replication with failover
+- [ ] Build a load balancer for read/write traffic distribution
+- [ ] Test with simulated high read/write workloads and measure latency
+  - Site: [System Design Questions (Arpit B Bhayani)](https://github.com/arpitbbhayani/system-design-questions)
+- [ ] Implement distributed caching layer with cache-aside and write-through strategies
+
+### Project 3: Event-Driven Notification Service
+
+- [ ] Design the event model — UserRegistered, PaymentCompleted, OrderShipped domain events
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Implement a message bus with RabbitMQ for event routing
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Build command handlers for user-triggered actions (send, schedule, cancel notifications)
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Implement multi-channel delivery — email, push notifications, SMS with retry logic
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Add dead letter queue for failed deliveries and monitoring dashboards
+- [ ] Implement Idempotent notification handlers to prevent duplicates
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Design a Saga pattern for order completion → notifications → audit logging
+
+### Project 4: Image Service & Video Pipeline with CQRS
+
+- [ ] Design separate read and write models — upload pipeline vs image gallery queries
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Implement CQRS — write side with Unit of Work, read side with denormalized view models
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Build an image/video upload service with CDN distribution
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+- [ ] Implement video transcoding pipeline with multiple quality levels
+- [ ] Build a search index using Elasticsearch for image metadata and tags
+- [ ] Implement event-driven sync between write model and read projections
+  - Book: "Architecture Patterns with Python" by Harry Percival & Bob Gregory
+- [ ] Add adaptive bitrate streaming for video playback
+  - Book: "System Design Interview – An Insider's Guide" by Alex Xu
+
+## Weekly Schedule Suggestion
+
+- 3 hours theory per week
+- 2 hours hands-on coding per week
+- 1 hour review/notes per week
+- Weekend: 1 project milestone or challenge

--- a/src/StudyPlans/plans.json
+++ b/src/StudyPlans/plans.json
@@ -1,4 +1,5 @@
 [
   "networking.md",
-  "claude-certified-developer-foundations.md"
+  "claude-certified-developer-foundations.md",
+  "algorithms-and-leetcode.md"
 ]

--- a/src/StudyPlans/plans.json
+++ b/src/StudyPlans/plans.json
@@ -1,5 +1,6 @@
 [
   "networking.md",
   "claude-certified-developer-foundations.md",
-  "algorithms-and-leetcode.md"
+  "algorithms-and-leetcode.md",
+  "code-architecture-system-design.md"
 ]


### PR DESCRIPTION
Closes #72

## What

Adds two structured study plans to  — one for algorithms/LeetCode and one for code architecture/system design.

## Why

The portfolio site lacked organized learning resources for technical topics. These study plans give visitors actionable, phased learning paths that combine canonical books with hands-on coding practice and system design interview questions. They also demonstrate the portfolio's quick-study-plan skill workflow.

## Changes

- created `src/StudyPlans/algorithms-and-leetcode.md`

- created `src/StudyPlans/code-architecture-system-design.md`

- Appends both new plan filenames to the manifest.

## How it works

1. Each plan follows the  structure: phased weeks with  checkbox tasks, resource sub-links (Book/Site/Video), and a Weekly Schedule Suggestion footer.
2. Algorithms plan maps each Grokking Algorithms chapter to a week, then attaches relevant Blind-75 LeetCode problems by topic (e.g. sorting week → Two Sum, Contains Duplicate).
3. System design plan creates a parallel structure: each phase combines theory from both books with practical design questions from the arpitbbhayani/system-design-questions repo.
4. The plans.json manifest is appended (never modified in-place) so the study-plan page can dynamically list all available plans.

## To verify

1. Open  and  to review plan structure and task coverage.
2. Run  is not needed (JSON), but validate with `[
    "networking.md",
    "claude-certified-developer-foundations.md",
    "algorithms-and-leetcode.md",
    "code-architecture-system-design.md"
].`
3. Confirm both filenames appear in  and are not duplicates.